### PR TITLE
Add context intervention research section

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ Full cards, takeaway plaques, an icon skeleton: three semantic tiers, every step
 </tr>
 </table>
 
+## Research · Context Intervention Benchmark
+
+ThoughtDAG is also a testbed for studying how LLMs respond when visible context is polluted, pruned or recomputed.
+
+**Current release — Context Repair Pilot v1**<br>
+`4 models` · `540 conditions` · `Updated August 2026`
+
+Deleting only the source repaired **68/72** derailed model-cases. Removing the contaminated subgraph repaired **72/72**. The residual error remained visible in downstream turns, so this is a result about context intervention—not hidden model memory or a general model ranking.
+
+*Models tested: Nemotron 3.5 Lightning, GLM 4.5 Flash, GPT-OSS 20B and Gemma 4 26B.*
+
+🧪 **[Read the case study](https://chenxiachan.github.io/thoughtdag/stories/context-repair/)** · 📊 **[Full methodology and results](https://chenxiachan.github.io/thoughtdag/research/context-repair-pilot-v1/)** · 💬 **[Suggest the next model](https://github.com/chenxiachan/thoughtdag/issues/new)**
+
 ## Quick start
 
 The [desktop app](#desktop-app) is the primary way to run ThoughtDAG: download, open, think. Running from source works too:

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -96,6 +96,19 @@ https://github.com/user-attachments/assets/f0362497-0e80-4caa-8214-cdbac92ab77c
 </tr>
 </table>
 
+## 研究 · Context Intervention Benchmark
+
+除了作为思考工具，ThoughtDAG 也可以用来研究：当可见上下文被污染、剪枝或重新计算时，不同 LLM 会如何响应。
+
+**当前版本：Context Repair Pilot v1**<br>
+`4 个模型` · `540 个实验条件` · `2026 年 8 月更新`
+
+只删除错误源头，修复了 **68/72** 个被带偏的模型案例；删除污染子图，修复了 **72/72**。错误残留在可见的下游对话中，因此这是关于上下文干预的实验结果，不是对隐藏模型记忆的解释，也不是通用模型排名。
+
+*已测试模型：Nemotron 3.5 Lightning、GLM 4.5 Flash、GPT-OSS 20B 和 Gemma 4 26B。*
+
+🧪 **[阅读案例](https://chenxiachan.github.io/thoughtdag/stories/context-repair/?lang=zh)** · 📊 **[完整方法与结果](https://chenxiachan.github.io/thoughtdag/research/context-repair-pilot-v1/?lang=zh)** · 💬 **[建议下一个模型](https://github.com/chenxiachan/thoughtdag/issues/new)**
+
 ## 快速开始
 
 首选[桌面版](#桌面版)：下载、打开、开始思考。从源码运行也可以：


### PR DESCRIPTION
Adds the approved Context Intervention Benchmark section to the English and Chinese READMEs. Links to the case study and full methodology, reports the current pilot result, and keeps the section compact for future model updates.\n\nValidation: git diff --check