### PR TITLE
Refine README and thank first supporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Connect a local Ollama or any OpenAI-compatible endpoint. Built-in presets, subs
 
 With gratitude to **@andreilaiter**, ThoughtDAG's first supporter, and to everyone helping this independent open-source project grow.
 
-[Support ThoughtDAG →](https://buymeacoffee.com/chatchan92)
+<a href="https://buymeacoffee.com/chatchan92"><img src="docs/supporters/support-thoughtdag.svg" alt="Support ThoughtDAG" width="252" /></a>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,14 @@
 
 **Your thinking deserves a map.** An infinite canvas where LLM conversations grow into an editable thought graph.
 
-![React](https://img.shields.io/badge/React_19-087EA4?logo=react&logoColor=white)
-![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Status](https://img.shields.io/badge/status-active_development-6B5CE7)
 
 ### [Download ↓](https://chenxiachan.github.io/thoughtdag/#download) · [Website](https://chenxiachan.github.io/thoughtdag/)
 
-[中文](./README_ZH.md) · [Quick start](#quick-start) · [Desktop app](#desktop-app) · [How it differs](#how-thoughtdag-differs) · [Models & subscriptions](#models--subscriptions) · [Cost & privacy](#cost--privacy)
+[中文](./README_ZH.md) · [Quick start](#quick-start) · [How it differs](#how-thoughtdag-differs) · [Research](#research--context-intervention-benchmark) · [Models & privacy](#models-cost--privacy)
 
 <img src="docs/hero-demo-en.gif" alt="Hero demo, recorded from the live app: selecting a passage in the PDF reader and asking about it; deleting a noise edge and regenerating a clean answer; zooming out through three semantic tiers to the map; opening the backup control center and exporting a real file" width="100%"/>
-
-<a href="https://www.youtube.com/watch?v=-8BqAyaoNXQ"><img src="https://img.youtube.com/vi/-8BqAyaoNXQ/maxresdefault.jpg" width="440" alt="Video thumbnail: the ThoughtDAG canvas mid-conversation" /></a>
 
 **[▶ The 33-second narrated tour](https://www.youtube.com/watch?v=-8BqAyaoNXQ)**
 
@@ -26,6 +22,8 @@
 ## The one rule
 
 > **Wires are the context.** What the model sees is exactly what wires into the node. Editing the graph edits the model's memory.
+
+Many tools put conversations on a canvas. In ThoughtDAG, a wire is not decoration or an execution route. It determines what the model sees next.
 
 ## In action
 
@@ -59,59 +57,36 @@ Select a passage, ask right there. The answer lands on the canvas with its page 
 
 <table>
 <tr>
-<td width="45%"><img src="docs/illus/condense-en.svg" alt="Illustration: three small highlighted cards converge through wires into one synthesis card, above a small timeline with cognitive badges"/></td>
-<td width="55%">
-
-### 💎 Thinking condenses in your hands
-
-Merge nodes into one higher conclusion; weave highlights into a summary. The graph folds inward instead of sprawling. **The human refines in the loop.**
-
-</td>
-</tr>
-</table>
-
-<table>
-<tr>
-<td width="55%">
-
-### 🖍️ The passages you marked, woven into cited prose
-
-Highlights are your judgment, not the model's. Check any subset and weave one passage where every sentence traces back.
-
-</td>
-<td width="45%"><img src="docs/illus/weave-en.svg" alt="Illustration: a highlighted sentence in a card woven into a cited passage below, with reference numbers"/></td>
-</tr>
-</table>
-
-<table>
-<tr>
 <td width="45%"><img src="docs/illus/map-en.svg" alt="Illustration: three takeaway plaques with ruled-out, decided and pivoted badges, linked by dashed lines"/></td>
 <td width="55%">
 
-### 🗺️ Zoom out: thinking becomes a map
+### 💎 Condense the graph, then zoom out
 
-Full cards, takeaway plaques, an icon skeleton: three semantic tiers, every step badged ✕ ⚖ ↩ ?. **The detours are part of the map.**
+Merge nodes into one higher conclusion; weave your highlights into cited prose. Then zoom through full cards, takeaway plaques and an icon skeleton. **The graph folds inward instead of sprawling.**
 
 </td>
 </tr>
 </table>
 
-## Research · Context Intervention Benchmark
+## How ThoughtDAG differs
 
-ThoughtDAG is also a testbed for studying how LLMs respond when visible context is polluted, pruned or recomputed.
+| Type | What a wire means | Better for |
+|------|-------------------|------------|
+| Linear chat | Conversation history in time order | Quick, simple questions |
+| Mind maps and whiteboards | Visual relations for human eyes | Free-form organizing and presenting |
+| Branching chat canvases | Parent-child forks of a conversation | Exploring alternative responses |
+| Workflow and agent canvases | Data flow or execution order | Automation and orchestration |
+| ThoughtDAG | The context the model actually receives next | Deliberate forking, merging, pruning and tracing of long-running thinking |
 
-**Current release — Context Repair Pilot v1**<br>
-`4 models` · `540 conditions` · `Updated August 2026`
-
-Deleting only the source repaired **68/72** derailed model-cases. Removing the contaminated subgraph repaired **72/72**. The residual error remained visible in downstream turns, so this is a result about context intervention—not hidden model memory or a general model ranking.
-
-*Models tested: Nemotron 3.5 Lightning, GLM 4.5 Flash, GPT-OSS 20B and Gemma 4 26B.*
-
-🧪 **[Read the case study](https://chenxiachan.github.io/thoughtdag/stories/context-repair/)** · 📊 **[Full methodology and results](https://chenxiachan.github.io/thoughtdag/research/context-repair-pilot-v1/)** · 💬 **[Suggest the next model](https://github.com/chenxiachan/thoughtdag/issues/new)**
+If you already keep a hand-maintained decision tree in a markdown file, ThoughtDAG is that tree made operational: the model reads exactly the branches you wire in.
 
 ## Quick start
 
-The [desktop app](#desktop-app) is the primary way to run ThoughtDAG: download, open, think. Running from source works too:
+### Desktop app
+
+Download, open, think. The [download page](https://chenxiachan.github.io/thoughtdag/#download) detects your platform and gives you the right installer; [Releases](https://github.com/chenxiachan/thoughtdag/releases/latest) keeps every build. macOS builds are signed and notarized. Windows builds are not signed yet and may show a SmartScreen warning.
+
+### Run from source
 
 ```bash
 npm install
@@ -120,26 +95,19 @@ npm run dev       # → localhost:5173
 # No .env? Connect any OpenAI-compatible endpoint inside the app
 ```
 
+Environment variables, local models and connection details → [docs/setup.md](docs/setup.md)
+
+### Browser demo
+
 Want a ten-second look before installing anything? The [hosted demo](https://app.thoughtdag.workers.dev) runs in the browser, and the example canvas needs no key. It is a feature subset: keyless web search, some direct-connection tools and the subscription bridge are desktop/local-only.
 
-The landing page offers the seeded example canvas one labeled click away: four chapters around one everyday question (why saved articles stay unread), including a reading loop with a real embedded PDF. Environment variables, free keys and configuration details → [docs/setup.md](docs/setup.md)
+## Research · Context Intervention Benchmark
 
-## Desktop app
+ThoughtDAG is also a testbed for a concrete question: when misleading context enters an LLM conversation, how much of the affected path must be removed before the answer recovers?
 
-The same app in its own window, with the local server bundled. No Node, no terminal. The easiest path is the [download page](https://chenxiachan.github.io/thoughtdag/#download): it detects your platform and hands you the right file.
+In the first pilot, deleting only the source repaired **68/72** derailed model-cases. Removing the contaminated subgraph repaired **72/72**. This does not explain hidden model reasoning or rank models; it tests how changing visible context changes the next answer.
 
-Downloading from [Releases](https://github.com/chenxiachan/thoughtdag/releases/latest) directly? Pick by system:
-
-| Your system | File to download |
-|-------------|------------------|
-| macOS, Apple Silicon (M1 and later) | `ThoughtDAG-x.y.z-arm64.dmg` |
-| macOS, Intel | `ThoughtDAG-x.y.z.dmg` |
-| Windows | `ThoughtDAG.Setup.x.y.z.exe` |
-| Linux | `ThoughtDAG-x.y.z.AppImage` |
-
-Not sure which Mac you have? Apple menu → About This Mac. The `.zip`, `.blockmap` and `.yml` files serve the in-app updater; you never download them by hand.
-
-The macOS builds are signed and notarized by Apple: double-click and go. Windows builds are not signed yet; choose "More info → Run anyway" on the SmartScreen prompt. After installing, the app checks for new versions itself (canvas menu → Check for updates) and every step past looking waits for your click.
+🧪 **[Read the first case study](https://chenxiachan.github.io/thoughtdag/stories/context-repair/)** · 📊 **[Methodology and results](https://chenxiachan.github.io/thoughtdag/research/context-repair-pilot-v1/)** · 💬 **[Suggest a model for the next run](https://github.com/chenxiachan/thoughtdag/issues/new)**
 
 ## More capabilities
 
@@ -153,45 +121,24 @@ The macOS builds are signed and notarized by Apple: double-click and go. Windows
 
 Full feature list (60+, grouped by area) → [docs/features.md](docs/features.md)
 
-## How ThoughtDAG differs
-
-Many tools put conversations on a canvas. The difference is what the connections do.
-
-In ThoughtDAG, a wire is not decoration or an execution route. It determines what the model sees next.
-
-| Type | What a wire means | Better for |
-|------|-------------------|------------|
-| Linear chat | Conversation history in time order | Quick, simple questions |
-| Mind maps and whiteboards | Visual relations for human eyes | Free-form organizing and presenting |
-| Branching chat canvases | Parent-child forks of a conversation | Exploring alternative responses |
-| Workflow and agent canvases | Data flow or execution order | Automation and orchestration |
-| ThoughtDAG | The context the model actually receives next | Deliberate forking, merging, pruning and tracing of long-running thinking |
-
-If you already keep a hand-maintained decision tree in a markdown file, ThoughtDAG is that tree made operational: the model reads exactly the branches you wire in.
-
 ### Works beside your coding agent
 
-Give the canvas a folder and it becomes a live local file: turn on **automatic folder backup**, point it at your project directory, and every new node you land updates `<canvas-name>.thoughtdag.json` on disk as you work. And coding agents read files. That is the whole integration:
+Automatic folder backup keeps the canvas as a live `.thoughtdag.json` file in your project; Markdown export turns any context chain or selection into a plain `.md`. Coding agents can read either without a plugin, API or server.
 
-1. Ask your agent CLI to read the file. The `question`, `response` and `summaries` fields carry your full decision history, including which paths were ruled out and why.
-2. For the cleanest handoff, use **Markdown export**: any context chain or selection becomes a plain `.md` the agent reads natively.
+## Models, cost & privacy
 
-Example, inside any agent session: *"Read ./notes/research.thoughtdag.json and continue from the conclusions; the summaries field lists what was already ruled out."*
-
-No plugin, no API, no server. The same file doubles as real data safety: point the backup at a synced folder and it is also your cross-device backup.
-
-## Models & subscriptions
-
-Zhipu · Qwen · OpenAI · Anthropic · Google · DeepSeek · Kimi · OpenRouter · Ollama, or any OpenAI-compatible endpoint. Text-only models read already-indexed images through their companion text; unread images go to a vision model, announced. Environment variables and default models → [docs/setup.md](docs/setup.md)
-
-**Already paying for a subscription? It plugs in.** A ChatGPT plan connects through a one-command local bridge (with ThoughtDAG running locally). GLM Coding and Kimi Code plans issue real API keys: pick the preset, paste the key, done. Setup for all three → [docs/setup.md#subscriptions](docs/setup.md#subscriptions)
-
-## Cost & privacy
+Connect a local Ollama or any OpenAI-compatible endpoint. Built-in presets, subscription connections and environment variables are documented in [setup](docs/setup.md).
 
 - **The free model tier covers every feature**; a local Ollama runs fully offline
 - **In the desktop app everything lives on your machine**: canvases, keys, documents; on the web demo, model traffic runs browser-direct and keys never touch the server
 - **PDFs never leave your machine**; only extracted text travels when you ask
 - **The backup format stays backward compatible**; Markdown export is the permanent escape hatch
+
+## Supporters
+
+With gratitude to **@andreilaiter**, ThoughtDAG's first supporter, and to everyone helping this independent open-source project grow.
+
+[Support ThoughtDAG →](https://buymeacoffee.com/chatchan92)
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -138,7 +138,7 @@ ThoughtDAG 也在检验一个具体问题：错误信息进入一段 LLM 对话�
 
 感谢首位支持者 **@andreilaiter**，也感谢每一位帮助这个独立开源项目继续成长的人。
 
-[支持 ThoughtDAG →](https://buymeacoffee.com/chatchan92)
+<a href="https://buymeacoffee.com/chatchan92"><img src="docs/supporters/support-thoughtdag.svg" alt="支持 ThoughtDAG" width="252" /></a>
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -6,26 +6,24 @@
 
 **思考值得一张地图。** 在无限画布上，AI 对话长成一张可编辑的思维图。
 
-![React](https://img.shields.io/badge/React_19-087EA4?logo=react&logoColor=white)
-![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white)
 ![License](https://img.shields.io/badge/许可-MIT-green)
 ![Status](https://img.shields.io/badge/状态-活跃开发中-6B5CE7)
 
 ### [下载桌面版 ↓](https://chenxiachan.github.io/thoughtdag/?lang=zh#download) · [官网](https://chenxiachan.github.io/thoughtdag/?lang=zh)
 
-[English](./README.md) · [快速开始](#快速开始) · [桌面版](#桌面版) · [有何不同](#thoughtdag-有何不同) · [模型与订阅](#模型与订阅) · [成本与隐私](#成本与隐私)
+[English](./README.md) · [快速开始](#快速开始) · [有何不同](#thoughtdag-有何不同) · [研究](#研究--上下文干预基准) · [模型与隐私](#模型成本与隐私)
 
 <img src="docs/hero-demo-zh.gif" alt="真实录屏的 Hero 演示：在 PDF 阅读器圈选段落提问；删掉噪音边重新生成干净答案；三层语义缩放缩到地图形态；打开备份控制中心导出真实文件" width="100%"/>
 
 </div>
 
-**▶ 33 秒旁白讲解，页面内直接播放：**
-
-https://github.com/user-attachments/assets/f0362497-0e80-4caa-8214-cdbac92ab77c
+**[▶ 33 秒旁白讲解](https://github.com/user-attachments/assets/f0362497-0e80-4caa-8214-cdbac92ab77c)**
 
 ## 唯一法则
 
 > **连线即上下文。** 模型看到的，精确等于连进节点的内容。编辑图，就是在编辑模型的记忆。
+
+很多工具都把对话放上画布。在 ThoughtDAG 里，连线不是装饰，也不是执行路径。它决定模型下一次看到什么。
 
 ## 它长什么样
 
@@ -59,59 +57,36 @@ https://github.com/user-attachments/assets/f0362497-0e80-4caa-8214-cdbac92ab77c
 
 <table>
 <tr>
-<td width="45%"><img src="docs/illus/condense-zh.svg" alt="示意图：三张带高光的小卡由连线汇聚成一张综合卡，下方一条带认知徽章的小时间轴"/></td>
-<td width="55%">
-
-### 💎 思考在你手里不断凝练
-
-节点合并成更高的结论，高光串成总结。图不断收拢，而不是不断膨胀。**人在回路中提炼。**
-
-</td>
-</tr>
-</table>
-
-<table>
-<tr>
-<td width="55%">
-
-### 🖍️ 你标的重点，串成带引用的文字
-
-高光是你的判断，不是模型的。勾选几条，串成每句可溯源的一段话。
-
-</td>
-<td width="45%"><img src="docs/illus/weave-zh.svg" alt="示意图：高光卡片里的一句话被串联进下方带引用编号的成文段落"/></td>
-</tr>
-</table>
-
-<table>
-<tr>
 <td width="45%"><img src="docs/illus/map-zh.svg" alt="示意图：三个收获句门牌，分别带排除、决策、转向徽章，虚线相连"/></td>
 <td width="55%">
 
-### 🗺️ 缩小画布，思考自成地图
+### 💎 先凝练，再看见整张地图
 
-完整卡片、收获句门牌、图标骨架三层缩放，每步带认知徽章 ✕ ⚖ ↩ ?。**走过的弯路也是地图的一部分。**
+节点合并成更高的结论，高光串成带引用的文字；继续缩小，完整卡片变成收获句门牌与图标骨架。**图不断收拢，而不是不断膨胀。**
 
 </td>
 </tr>
 </table>
 
-## 研究 · Context Intervention Benchmark
+## ThoughtDAG 有何不同
 
-除了作为思考工具，ThoughtDAG 也可以用来研究：当可见上下文被污染、剪枝或重新计算时，不同 LLM 会如何响应。
+| 类型 | 连线代表什么 | 更适合 |
+|------|------------|--------|
+| 线性聊天 | 时间顺序中的对话历史 | 简单、快速的问题 |
+| 思维导图与白板 | 给人看的视觉关系 | 自由整理与展示 |
+| 分支对话画布 | 对话的父子分支 | 探索不同回答路径 |
+| 工作流与 Agent 画布 | 数据流或执行顺序 | 自动化和流程编排 |
+| ThoughtDAG | 模型下一次真正接收的上下文 | 长线思考的人工分叉、合并、剪枝与追溯 |
 
-**当前版本：Context Repair Pilot v1**<br>
-`4 个模型` · `540 个实验条件` · `2026 年 8 月更新`
-
-只删除错误源头，修复了 **68/72** 个被带偏的模型案例；删除污染子图，修复了 **72/72**。错误残留在可见的下游对话中，因此这是关于上下文干预的实验结果，不是对隐藏模型记忆的解释，也不是通用模型排名。
-
-*已测试模型：Nemotron 3.5 Lightning、GLM 4.5 Flash、GPT-OSS 20B 和 Gemma 4 26B。*
-
-🧪 **[阅读案例](https://chenxiachan.github.io/thoughtdag/stories/context-repair/?lang=zh)** · 📊 **[完整方法与结果](https://chenxiachan.github.io/thoughtdag/research/context-repair-pilot-v1/?lang=zh)** · 💬 **[建议下一个模型](https://github.com/chenxiachan/thoughtdag/issues/new)**
+如果你已经在用一个 markdown 文件手工维护决策树，ThoughtDAG 就是那棵树的可操作版本：你连进来的分支，就是模型读到的全部。
 
 ## 快速开始
 
-首选[桌面版](#桌面版)：下载、打开、开始思考。从源码运行也可以：
+### 桌面版
+
+下载、打开、开始思考。[下载页](https://chenxiachan.github.io/thoughtdag/?lang=zh#download)会自动识别系统并给出对应安装包；全部构建可在 [Releases](https://github.com/chenxiachan/thoughtdag/releases/latest) 找到。macOS 版已签名与公证；Windows 版暂未签名，可能出现 SmartScreen 提示。
+
+### 从源码运行
 
 ```bash
 npm install
@@ -120,26 +95,19 @@ npm run dev       # → localhost:5173
 # 无 .env 时，在应用内连接任意兼容 OpenAI 协议的接口即可
 ```
 
+环境变量、本地模型与连接方式 → [docs/setup_ZH.md](docs/setup_ZH.md)
+
+### 在线体验
+
 想先花十秒看看再决定装不装？[在线 Demo](https://app.thoughtdag.workers.dev) 在浏览器里直接跑，示例画布免 key。注意它是功能子集：免 key 联网搜索、部分直连工具和订阅桥只在桌面版/本地可用。
 
-首页一键载入预置的示例画布：围绕「收藏夹为什么总在吃灰」展开四章，含一份内嵌真 PDF 的阅读闭环。环境变量、免费 key 与配置细节 → [docs/setup_ZH.md](docs/setup_ZH.md)
+## 研究 · 上下文干预基准
 
-## 桌面版
+ThoughtDAG 也在检验一个具体问题：错误信息进入一段 LLM 对话后，究竟要移除多少受影响的路径，回答才会恢复？
 
-同一个应用装进独立窗口，内置本地引擎。不需要 Node，不需要终端。最省事的入口是[下载页](https://chenxiachan.github.io/thoughtdag/?lang=zh#download)，页面会自动识别你的平台并直接给出安装包。
+首轮实验中，只删除错误源头修复了 **68/72** 个被带偏的案例；移除受污染的下游子图后，修复了 **72/72**。这个实验不解释模型内部为何这样回答，也不做通用模型排名；它检验的是：改变模型可见的上下文，会怎样改变下一次回答。
 
-直接从 [Releases](https://github.com/chenxiachan/thoughtdag/releases/latest) 下载的话，按系统对照选择：
-
-| 你的系统 | 下载这个文件 |
-|---------|-------------|
-| macOS，Apple Silicon（M1 及之后） | `ThoughtDAG-x.y.z-arm64.dmg` |
-| macOS，Intel 芯片 | `ThoughtDAG-x.y.z.dmg` |
-| Windows | `ThoughtDAG.Setup.x.y.z.exe` |
-| Linux | `ThoughtDAG-x.y.z.AppImage` |
-
-不确定自己的 Mac 是哪种芯片：苹果菜单 → 关于本机。列表里的 `.zip`、`.blockmap` 和 `.yml` 文件是应用内自动更新机制使用的，不需要手动下载。
-
-macOS 版已由 Apple 签名与公证，双击即开。Windows 版暂未签名，在提示中选「更多信息 → 仍要运行」。装好之后应用会自己检查新版本（画布菜单 → 检查更新），检查之后的每一步都等你点击确认。
+🧪 **[阅读首轮案例](https://chenxiachan.github.io/thoughtdag/stories/context-repair/?lang=zh)** · 📊 **[实验方法与结果](https://chenxiachan.github.io/thoughtdag/research/context-repair-pilot-v1/?lang=zh)** · 💬 **[建议下一轮测试模型](https://github.com/chenxiachan/thoughtdag/issues/new)**
 
 ## 更多能力
 
@@ -153,45 +121,24 @@ macOS 版已由 Apple 签名与公证，双击即开。Windows 版暂未签名�
 
 完整功能清单（60+ 条，按领域分组）→ [docs/features_ZH.md](docs/features_ZH.md)
 
-## ThoughtDAG 有何不同
-
-很多工具都把对话放上画布。真正的区别在于，连线做什么。
-
-在 ThoughtDAG 里，连线不是装饰，也不是执行路径。它决定模型下一次看到什么。
-
-| 类型 | 连线代表什么 | 更适合 |
-|------|------------|--------|
-| 线性聊天 | 时间顺序中的对话历史 | 简单、快速的问题 |
-| 思维导图与白板 | 给人看的视觉关系 | 自由整理与展示 |
-| 分支对话画布 | 对话的父子分支 | 探索不同回答路径 |
-| 工作流与 Agent 画布 | 数据流或执行顺序 | 自动化和流程编排 |
-| ThoughtDAG | 模型下一次真正接收的上下文 | 长线思考的人工分叉、合并、剪枝与追溯 |
-
-如果你已经在用一个 markdown 文件手工维护决策树，ThoughtDAG 就是那棵树的可操作版本：你连进来的分支，就是模型读到的全部。
-
 ### 和 coding agent 并肩工作
 
-给画布安一个文件夹，它就是一个自动更新的本地文件：打开**自动文件夹备份**，指到你的项目目录，你每落一个新节点，磁盘上的 `<画布名>.thoughtdag.json` 就跟着更新。而 coding agent 天生会读文件。集成的全部就是这样：
+自动文件夹备份会把画布持续写成项目里的 `.thoughtdag.json`；Markdown 导出则把任意上下文链或选区变成普通 `.md`。coding agent 无需插件、API 或额外服务即可读取。
 
-1. 让你的 agent CLI 读这个文件。`question`、`response`、`summaries` 字段承载完整的决策历史，包括哪些路已经被排除、为什么。
-2. 要最干净的交接，用 **Markdown 导出**：任意上下文链或选区变成 agent 原生可读的 `.md`。
+## 模型、成本与隐私
 
-在任意 agent 会话里的用法示例：*「读一下 ./notes/research.thoughtdag.json，从里面的结论继续；summaries 字段列了已经排除的路线。」*
-
-没有插件，没有 API，没有服务。同一份文件也是真实的数据安全：把备份指到网盘同步目录，它就是你的跨设备备份。
-
-## 模型与订阅
-
-智谱 · 通义 · OpenAI · Anthropic · Google · DeepSeek · Kimi · OpenRouter · Ollama，或任何兼容 OpenAI 协议的端点。纯文本模型经伴随文本读图，未识读的图才由视觉模型代答（有提示）。环境变量与默认模型 → [docs/setup_ZH.md](docs/setup_ZH.md)
-
-**已经在付订阅费？直接接进来。** ChatGPT 订阅经一条命令的本地桥接入（配合本地运行的 ThoughtDAG）；GLM Coding 与 Kimi Code 订阅本身就发 API key，选预设、填 key 即可。三家的接法 → [docs/setup_ZH.md#订阅接入](docs/setup_ZH.md#订阅接入)
-
-## 成本与隐私
+连接本地 Ollama 或任意兼容 OpenAI 协议的端点。内置预设、订阅接入与环境变量说明统一放在[配置文档](docs/setup_ZH.md)。
 
 - **免费档模型覆盖全部功能**；本地 Ollama 完全离线
 - **桌面版一切都在本机**：画布、key、文档；在线 Demo 的模型流量浏览器直连，key 不经服务器
 - **PDF 不离机**，只有提取文本随提问发出
 - **备份格式向后兼容**；Markdown 导出是永久逃生门
+
+## 支持者
+
+感谢首位支持者 **@andreilaiter**，也感谢每一位帮助这个独立开源项目继续成长的人。
+
+[支持 ThoughtDAG →](https://buymeacoffee.com/chatchan92)
 
 ---
 

--- a/docs/supporters/support-thoughtdag.svg
+++ b/docs/supporters/support-thoughtdag.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="252" height="52" viewBox="0 0 252 52" role="img" aria-labelledby="title desc">
+  <title id="title">Support ThoughtDAG</title>
+  <desc id="desc">A dark rounded badge linking to the ThoughtDAG support page.</desc>
+  <rect x="0.75" y="0.75" width="250.5" height="50.5" rx="14" fill="#171525" stroke="#353149" stroke-width="1.5"/>
+  <circle cx="28" cy="26" r="15" fill="#F6C85F"/>
+  <path d="M20 20.5h13v8.2a5.3 5.3 0 0 1-5.3 5.3h-2.4a5.3 5.3 0 0 1-5.3-5.3v-8.2Z" fill="#171525"/>
+  <path d="M33 22.8h2.1a3.3 3.3 0 0 1 0 6.6H33" fill="none" stroke="#171525" stroke-width="2.2" stroke-linecap="round"/>
+  <path d="M23 17.2c0-1.7 1.8-1.7 1.8-3.4M28 17.2c0-1.7 1.8-1.7 1.8-3.4" fill="none" stroke="#171525" stroke-width="1.7" stroke-linecap="round"/>
+  <text x="53" y="23" fill="#B8B3CC" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="10" font-weight="700" letter-spacing="1.4">KEEP THE GRAPH GROWING</text>
+  <text x="53" y="38" fill="#FFFFFF" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="15" font-weight="700">Support ThoughtDAG</text>
+</svg>


### PR DESCRIPTION
## Summary
- simplify and reorganize the English and Chinese README structure
- clarify how ThoughtDAG differs, quick-start paths, and the context-intervention research section
- thank the first supporter at the end of each README without linking their identity

## Validation
- staged scope verified: README.md and README_ZH.md only
- git diff --cached --check passed before commit