### PR TITLE
Refine README positioning and research section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@
 
 ### [Download ↓](https://chenxiachan.github.io/thoughtdag/#download) · [Website](https://chenxiachan.github.io/thoughtdag/)
 
-[中文](./README_ZH.md) · [Quick start](#quick-start) · [How it differs](#how-thoughtdag-differs) · [Research](#research--context-intervention-benchmark) · [Models & privacy](#models-cost--privacy)
+[中文](./README_ZH.md) · [Quick start](#quick-start) · [How it differs](#how-thoughtdag-differs) · [Research](#-research-why-editable-context-matters) · [Models & privacy](#models-cost--privacy)
 
 <img src="docs/hero-demo-en.gif" alt="Hero demo, recorded from the live app: selecting a passage in the PDF reader and asking about it; deleting a noise edge and regenerating a clean answer; zooming out through three semantic tiers to the map; opening the backup control center and exporting a real file" width="100%"/>
+
+<p align="center"><a href="https://www.youtube.com/watch?v=-8BqAyaoNXQ"><img src="https://img.youtube.com/vi/-8BqAyaoNXQ/maxresdefault.jpg" alt="YouTube thumbnail for the ThoughtDAG narrated tour" width="640" /></a></p>
 
 **[▶ The 33-second narrated tour](https://www.youtube.com/watch?v=-8BqAyaoNXQ)**
 
@@ -70,15 +72,17 @@ Merge nodes into one higher conclusion; weave your highlights into cited prose. 
 
 ## How ThoughtDAG differs
 
-| Type | What a wire means | Better for |
-|------|-------------------|------------|
-| Linear chat | Conversation history in time order | Quick, simple questions |
-| Mind maps and whiteboards | Visual relations for human eyes | Free-form organizing and presenting |
-| Branching chat canvases | Parent-child forks of a conversation | Exploring alternative responses |
-| Workflow and agent canvases | Data flow or execution order | Automation and orchestration |
-| ThoughtDAG | The context the model actually receives next | Deliberate forking, merging, pruning and tracing of long-running thinking |
+Many products use nodes and edges, but the graph does a different job in each category.
 
-If you already keep a hand-maintained decision tree in a markdown file, ThoughtDAG is that tree made operational: the model reads exactly the branches you wire in.
+| Product category | How it differs from ThoughtDAG |
+|---|---|
+| Linear chat | Context follows one chronological thread; ThoughtDAG selects and merges visible paths. |
+| Mind maps and whiteboards | Edges organize ideas for people; ThoughtDAG edges also change model input. |
+| Branching chat canvases | They usually follow one inherited branch; ThoughtDAG can merge or prune several paths. |
+| Workflow and agent canvases | Edges run tasks and data; ThoughtDAG edges control conversational context. |
+| RAG and automatic memory | The system retrieves context automatically; ThoughtDAG makes the selection visible and editable. |
+
+ThoughtDAG is a user-authored context graph: incoming paths and explicit references form the next request, while excluded work stays visible on the canvas.
 
 ## Quick start
 
@@ -101,13 +105,17 @@ Environment variables, local models and connection details → [docs/setup.md](d
 
 Want a ten-second look before installing anything? The [hosted demo](https://app.thoughtdag.workers.dev) runs in the browser, and the example canvas needs no key. It is a feature subset: keyless web search, some direct-connection tools and the subscription bridge are desktop/local-only.
 
-## Research · Context Intervention Benchmark
+## 🧪 Research: Why editable context matters
 
-ThoughtDAG is also a testbed for a concrete question: when misleading context enters an LLM conversation, how much of the affected path must be removed before the answer recovers?
+### Context Intervention Benchmark · Pilot v1
 
-In the first pilot, deleting only the source repaired **68/72** derailed model-cases. Removing the contaminated subgraph repaired **72/72**. This does not explain hidden model reasoning or rank models; it tests how changing visible context changes the next answer.
+When misleading context enters an LLM conversation, how much of the affected path must be removed before the answer recovers?
 
-🧪 **[Read the first case study](https://chenxiachan.github.io/thoughtdag/stories/context-repair/)** · 📊 **[Methodology and results](https://chenxiachan.github.io/thoughtdag/research/context-repair-pilot-v1/)** · 💬 **[Suggest a model for the next run](https://github.com/chenxiachan/thoughtdag/issues/new)**
+> **68/72** cases recovered after deleting only the misleading source. **72/72** recovered after removing the contaminated subgraph.
+
+This does not explain hidden model reasoning or rank models. It tests a narrower, observable claim: changing visible context changes the next answer.
+
+📖 **[Read the first case study](https://chenxiachan.github.io/thoughtdag/stories/context-repair/)** · 📊 **[Methodology and results](https://chenxiachan.github.io/thoughtdag/research/context-repair-pilot-v1/)** · 💬 **[Suggest a model for the next run](https://github.com/chenxiachan/thoughtdag/issues/new)**
 
 ## More capabilities
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -11,7 +11,7 @@
 
 ### [下载桌面版 ↓](https://chenxiachan.github.io/thoughtdag/?lang=zh#download) · [官网](https://chenxiachan.github.io/thoughtdag/?lang=zh)
 
-[English](./README.md) · [快速开始](#快速开始) · [有何不同](#thoughtdag-有何不同) · [研究](#研究--上下文干预基准) · [模型与隐私](#模型成本与隐私)
+[English](./README.md) · [快速开始](#快速开始) · [有何不同](#thoughtdag-和其他图形化-ai-工具有何不同) · [研究](#-研究为什么上下文需要可编辑) · [模型与隐私](#模型成本与隐私)
 
 <img src="docs/hero-demo-zh.gif" alt="真实录屏的 Hero 演示：在 PDF 阅读器圈选段落提问；删掉噪音边重新生成干净答案；三层语义缩放缩到地图形态；打开备份控制中心导出真实文件" width="100%"/>
 
@@ -68,17 +68,19 @@
 </tr>
 </table>
 
-## ThoughtDAG 有何不同
+## ThoughtDAG 和其他图形化 AI 工具有何不同
 
-| 类型 | 连线代表什么 | 更适合 |
-|------|------------|--------|
-| 线性聊天 | 时间顺序中的对话历史 | 简单、快速的问题 |
-| 思维导图与白板 | 给人看的视觉关系 | 自由整理与展示 |
-| 分支对话画布 | 对话的父子分支 | 探索不同回答路径 |
-| 工作流与 Agent 画布 | 数据流或执行顺序 | 自动化和流程编排 |
-| ThoughtDAG | 模型下一次真正接收的上下文 | 长线思考的人工分叉、合并、剪枝与追溯 |
+很多产品都有节点和连线，但这张图在不同产品中做的事并不一样。
 
-如果你已经在用一个 markdown 文件手工维护决策树，ThoughtDAG 就是那棵树的可操作版本：你连进来的分支，就是模型读到的全部。
+| 产品类别 | 与 ThoughtDAG 的区别 |
+|---|---|
+| 线性对话 | 上下文沿一条时间线累积；ThoughtDAG 可选择和合并可见路径。 |
+| 思维导图与数字白板 | 连线主要帮人整理概念；ThoughtDAG 的连线还会改变模型输入。 |
+| 分支对话画布 | 通常沿一条父链继承；ThoughtDAG 还能合并或剪枝多条路径。 |
+| 工作流与 Agent 画布 | 连线用于运行任务和传递数据；ThoughtDAG 的连线用于控制对话上下文。 |
+| RAG 与自动记忆 | 系统自动检索上下文；ThoughtDAG 让选择过程可见、可编辑。 |
+
+ThoughtDAG 是一张由人编辑的上下文图：连入节点的路径与显式引用构成下一次请求，被排除的内容则继续留在画布上。
 
 ## 快速开始
 
@@ -101,13 +103,17 @@ npm run dev       # → localhost:5173
 
 想先花十秒看看再决定装不装？[在线 Demo](https://app.thoughtdag.workers.dev) 在浏览器里直接跑，示例画布免 key。注意它是功能子集：免 key 联网搜索、部分直连工具和订阅桥只在桌面版/本地可用。
 
-## 研究 · 上下文干预基准
+## 🧪 研究：为什么上下文需要可编辑
 
-ThoughtDAG 也在检验一个具体问题：错误信息进入一段 LLM 对话后，究竟要移除多少受影响的路径，回答才会恢复？
+### 上下文干预基准 · 首轮实验
 
-首轮实验中，只删除错误源头修复了 **68/72** 个被带偏的案例；移除受污染的下游子图后，修复了 **72/72**。这个实验不解释模型内部为何这样回答，也不做通用模型排名；它检验的是：改变模型可见的上下文，会怎样改变下一次回答。
+错误信息进入一段 LLM 对话后，究竟要移除多少受影响的路径，回答才能恢复？
 
-🧪 **[阅读首轮案例](https://chenxiachan.github.io/thoughtdag/stories/context-repair/?lang=zh)** · 📊 **[实验方法与结果](https://chenxiachan.github.io/thoughtdag/research/context-repair-pilot-v1/?lang=zh)** · 💬 **[建议下一轮测试模型](https://github.com/chenxiachan/thoughtdag/issues/new)**
+> 只删除错误源头，修复了 **68/72** 个案例；移除受污染的子图后，修复了 **72/72**。
+
+这个实验不解释模型内部为何这样回答，也不做通用模型排名。它检验的是一个更窄、可观察的问题：改变可见上下文，会不会改变下一次回答？
+
+📖 **[阅读首轮案例](https://chenxiachan.github.io/thoughtdag/stories/context-repair/?lang=zh)** · 📊 **[实验方法与结果](https://chenxiachan.github.io/thoughtdag/research/context-repair-pilot-v1/?lang=zh)** · 💬 **[建议下一轮测试模型](https://github.com/chenxiachan/thoughtdag/issues/new)**
 
 ## 更多能力
 


### PR DESCRIPTION
## What changed

- restore the official YouTube thumbnail above the narrated tour
- explain ThoughtDAG by product category instead of an overly compressed feature table
- give the context-intervention research a clearer problem, benchmark label, result, and scope
- keep the English and Chinese READMEs aligned

## Why

The README should answer “ThoughtDAG vs X” quickly while giving the research evidence enough visual weight without adding landing-page clutter.

## Validation

- rendered both READMEs through GitHub’s Markdown API
- visually checked the English and Chinese previews
- ran `git diff --check`
- staged only `README.md` and `README_ZH.md`
