### PR TITLE
Fix Tidy layout placing a node with several parents under one arbitrary parent

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "smoke": "node scripts/smoke.mjs",
+    "test:layout": "node scripts/test-layout.mjs",
     "preview": "vite preview",
     "desktop": "npm run build && cd desktop && electron ."
   },

--- a/scripts/test-layout.mjs
+++ b/scripts/test-layout.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// Layout invariants. autoLayout is pure, but it lives in src/ where the module
+// graph reaches import.meta.env, so it is bundled for node the same way the
+// benchmark compiler bundles product code (benchmark/tools/build-bundle.sh).
+//
+// The rules being checked are the canvas grammar, not aesthetics:
+//   - a node CONTINUES below every parent it continues from
+//   - a node EXPLORED out of a parent stands beside it, never above its top
+//   - no two thought cards overlap
+//   - the same graph, handed over in a different order, lays out the same way
+//
+// Run: node scripts/test-layout.mjs
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const tmp = mkdtempSync(join(tmpdir(), 'tdag-layout-'));
+const bundle = join(tmp, 'layout.mjs');
+execFileSync(join(ROOT, 'node_modules/.bin/esbuild'), [
+  join(ROOT, 'src/lib/layout.ts'), '--bundle', '--format=esm', '--platform=node',
+  `--outfile=${bundle}`, '--define:import.meta.env.VITE_API_BASE=""',
+  '--define:import.meta.env.DEV=false',
+], { stdio: ['ignore', 'ignore', 'pipe'] });
+const { autoLayout, nodeHeight } = await import(pathToFileURL(bundle).href);
+
+let failures = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  ok   ${name}`); }
+  catch (e) { failures++; console.log(`  FAIL ${name}\n       ${e.message}`); }
+}
+const assert = (cond, msg) => { if (!cond) throw new Error(msg); };
+
+const NODE_W = 520;
+const CONTENT = new Set(['note', 'file', 'link', 'frame']);
+const th = (id, over = {}) => ({
+  id, type: 'thought', position: { x: 0, y: 0 },
+  data: {
+    question: 'q', response: 'r', responses: ['r'], responseIndex: 0,
+    isCollapsed: true, isEditing: false, isEditingResponse: false, isLoading: false,
+    tokenCount: 0, highlights: [], highlightMode: false, roleMode: 'assistant',
+    attachments: [], excludedAttachmentIds: [], includedAttachmentIds: [],
+    isRoot: false, isBranch: false, ...over,
+  },
+});
+const file = (id, x) => ({ ...th(id, { stepKind: 'file' }), position: { x, y: 0 }, measured: { width: 120, height: 120 } });
+const ed = (s, t, data) => ({ id: `${s}->${t}`, source: s, target: t, ...(data ? { data } : {}) });
+const xOf = (laid, id) => laid.find((n) => n.id === id).position.x;
+
+// Every arrow-order and overlap rule, checked per edge.
+function violations(laid, edges) {
+  const by = new Map(laid.map((n) => [n.id, n]));
+  const out = [];
+  for (const e of edges) {
+    if (e.data?.isCrossLink) continue;
+    const s = by.get(e.source), t = by.get(e.target);
+    if (!s || !t || CONTENT.has(s.data?.stepKind) || CONTENT.has(t.data?.stepKind)) continue;
+    if (e.data?.isBranchFromSelection) {
+      if (t.position.y < s.position.y) out.push(`explore ${e.source}->${e.target} above parent top`);
+    } else if (t.position.y < s.position.y + nodeHeight(s)) {
+      out.push(`structural ${e.source}->${e.target} above parent bottom`);
+    }
+  }
+  const solid = laid.filter((n) => !CONTENT.has(n.data?.stepKind));
+  for (let i = 0; i < solid.length; i++) for (let j = i + 1; j < solid.length; j++) {
+    const a = solid[i], b = solid[j];
+    if (a.position.x < b.position.x + NODE_W && b.position.x < a.position.x + NODE_W &&
+        a.position.y < b.position.y + nodeHeight(b) && b.position.y < a.position.y + nodeHeight(a))
+      out.push(`overlap ${a.id}/${b.id}`);
+  }
+  return out;
+}
+
+console.log('layout invariants\n');
+
+test('a merge is claimed by the parent in the median column, not the first', () => {
+  const nodes = ['root', 'p1', 'p2', 'p3', 'merge'].map((i) => th(i));
+  const edges = [ed('root', 'p1'), ed('root', 'p2'), ed('root', 'p3'),
+                 ed('p1', 'merge'), ed('p2', 'merge'), ed('p3', 'merge')];
+  const laid = autoLayout(nodes, edges);
+  assert(xOf(laid, 'merge') === xOf(laid, 'p2'),
+    `merge at ${xOf(laid, 'merge')}, median parent p2 at ${xOf(laid, 'p2')}`);
+});
+
+test('the same graph in a different node order lays out the same way', () => {
+  const ids = ['root', 'p1', 'p2', 'p3', 'merge'];
+  const edges = [ed('root', 'p1'), ed('root', 'p2'), ed('root', 'p3'),
+                 ed('p1', 'merge'), ed('p2', 'merge'), ed('p3', 'merge')];
+  const byId = new Map(ids.map((i) => [i, th(i)]));
+  const sig = (order) => autoLayout(order.map((i) => byId.get(i)), edges)
+    .map((n) => `${n.id}@${Math.round(n.position.x)},${Math.round(n.position.y)}`).sort().join('|');
+  const a = sig(ids), b = sig([...ids].reverse()), c = sig(['root', 'p3', 'p1', 'p2', 'merge']);
+  assert(a === b && b === c, 'layout changed when the node array was permuted');
+});
+
+test('an explore branch follows the merge that moves beneath its parents', () => {
+  const nodes = ['rootA', 'rootB', 'B', 'merge', 'branch'].map((i) => th(i));
+  const edges = [ed('rootB', 'B'), ed('rootA', 'merge'), ed('B', 'merge'),
+                 ed('merge', 'branch', { isBranchFromSelection: true })];
+  const laid = autoLayout(nodes, edges);
+  assert(violations(laid, edges).length === 0, violations(laid, edges).join('; '));
+});
+
+test('a merge continued from one parent and explored from another keeps the plain column', () => {
+  const nodes = ['explore', 'a', 'b', 'plain', 'merge'].map((i) => th(i));
+  const edges = [ed('a', 'b'), ed('b', 'plain'),
+                 ed('explore', 'merge', { isBranchFromSelection: true }), ed('plain', 'merge')];
+  const laid = autoLayout(nodes, edges);
+  assert(xOf(laid, 'merge') === xOf(laid, 'plain'),
+    `merge at ${xOf(laid, 'merge')}, plain parent at ${xOf(laid, 'plain')}`);
+});
+
+test('material-anchored parents rank by where they sit, not by traversal order', () => {
+  const nodes = [file('mLeft', 0), file('mMid', 1000), file('mRight', 2000),
+                 th('qRight'), th('qLeft'), th('qMid'), th('merge')];
+  const edges = [ed('mRight', 'qRight'), ed('mLeft', 'qLeft'), ed('mMid', 'qMid'),
+                 ed('qRight', 'merge'), ed('qLeft', 'merge'), ed('qMid', 'merge')];
+  const laid = autoLayout(nodes, edges);
+  assert(xOf(laid, 'merge') === xOf(laid, 'qMid'),
+    `merge at ${xOf(laid, 'merge')}, geometric median parent qMid at ${xOf(laid, 'qMid')}`);
+});
+
+test('a chain reading several documents starts among them', () => {
+  const nodes = [file('f0', 0), file('f1', 900), file('f2', 1800), file('f3', 2700), file('f4', 3600), th('synth')];
+  const edges = ['f0', 'f1', 'f2', 'f3', 'f4'].map((f) => ed(f, 'synth'));
+  const x = xOf(autoLayout(nodes, edges), 'synth');
+  assert(x > 900 && x < 2700, `synthesis at ${x}, outside the span of the documents it reads`);
+});
+
+test('the benchmark canvases keep the arrow order', () => {
+  const dir = join(ROOT, 'benchmark/canvases/inputs');
+  let checked = 0, bad = [];
+  for (const f of readdirSync(dir).filter((n) => n.endsWith('.thoughtdag.json'))) {
+    const c = JSON.parse(readFileSync(join(dir, f), 'utf8'));
+    const v = violations(autoLayout(c.nodes ?? [], c.edges ?? []), c.edges ?? []);
+    checked++;
+    if (v.length) bad.push(`${f}: ${v[0]}`);
+  }
+  assert(checked > 0, 'no benchmark canvases found');
+  assert(bad.length === 0, `${bad.length}/${checked} canvases violate: ${bad[0]}`);
+});
+
+rmSync(tmp, { recursive: true, force: true });
+console.log(failures ? `\n${failures} failing` : '\nall passed');
+process.exit(failures ? 1 : 0);

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -83,6 +83,13 @@ export function autoLayout(allNodes: ThoughtNode[], allEdges: ThoughtEdge[]): Th
   const targetIds = new Set(structuralEdges.map((e) => e.target));
   const roots = nodes.filter((n) => !targetIds.has(n.id));
 
+  const structuralParents = new Map<string, string[]>();
+  for (const e of structuralEdges) {
+    const list = structuralParents.get(e.target) || [];
+    list.push(e.source);
+    structuralParents.set(e.target, list);
+  }
+
   // ── Material anchors ──
   // Layout never moves content nodes, but chains GROWN FROM them must obey
   // the arrow grammar: the child starts BELOW its material, roughly under
@@ -96,12 +103,21 @@ export function autoLayout(allNodes: ThoughtNode[], allEdges: ThoughtEdge[]): Th
       .map((e) => allNodes.find((n) => n.id === e.source))
       .filter((m): m is ThoughtNode => !!m);
     if (mats.length === 0) continue;
+    // Two different questions, so two different materials answer them. The
+    // chain must start below the LOWEST material, or it collides with the one
+    // that hangs furthest down — that is a vertical question. But it should
+    // start in the MIDDLE of them horizontally, which the lowest material
+    // cannot answer: read a row of papers and the lowest is whichever card
+    // happens to hang furthest down, telling us nothing about left or right.
+    // Taking x from it parked the synthesis under one arbitrary document with
+    // the rest of its reading reaching across the canvas.
     const lowest = mats.reduce((a, b) =>
       a.position.y + nodeHeight(a) > b.position.y + nodeHeight(b) ? a : b);
+    const midX = mats.reduce((t, m) => t + m.position.x, 0) / mats.length;
     const k = perMaterialCount.get(lowest.id) ?? 0;
     perMaterialCount.set(lowest.id, k + 1);
     materialAnchors.set(root.id, {
-      x: lowest.position.x - 60 + k * (LAYOUT_COL_WIDTH + LAYOUT_H_GAP),
+      x: midX - 60 + k * (LAYOUT_COL_WIDTH + LAYOUT_H_GAP),
       y: lowest.position.y + nodeHeight(lowest) + LAYOUT_V_GAP,
     });
   }
@@ -113,22 +129,32 @@ export function autoLayout(allNodes: ThoughtNode[], allEdges: ThoughtEdge[]): Th
     childrenMap.set(edge.source, list);
   }
 
+  // Being explored out is a property of the EDGE, not of the node: a node can
+  // be explored out of one parent and continue plainly from another, and to
+  // that second parent it is an ordinary continuation.
+  const edgeKey = (parent: string, child: string) => `${parent}\u0000${child}`;
+  const exploreEdges = new Set(
+    edges
+      .filter((e) => e.data?.isBranchFromSelection)
+      .map((e) => edgeKey(e.source, e.target))
+  );
+
   // Classify children into 3 types:
   // 1. Continuation — first non-explore child, inherits parent column
   // 2. Regenerate siblings — other non-explore children, columns adjacent to parent
-  // 3. Explore branches — isBranchFromSelection, columns further out
-  const exploreTargets = new Set(
-    edges.filter((e) => e.data?.isBranchFromSelection).map((e) => e.target)
-  );
-
-  function classifyChildren(parentId: string): {
+  // 3. Explore branches — explored out of THIS parent, columns further out
+  function classifyChildren(parentId: string, claimant: Map<string, string>): {
     continuation: string | null;
     regenerates: string[];
     explores: string[];
   } {
-    const children = childrenMap.get(parentId) || [];
-    const nonExplore = children.filter((c) => !exploreTargets.has(c));
-    const explores = children.filter((c) => exploreTargets.has(c));
+    // A merge is laid out by one parent only; the others still draw their
+    // arrow to it, they just no longer decide where it sits.
+    const children = (childrenMap.get(parentId) || []).filter(
+      (c) => (claimant.get(c) ?? parentId) === parentId
+    );
+    const nonExplore = children.filter((c) => !exploreEdges.has(edgeKey(parentId, c)));
+    const explores = children.filter((c) => exploreEdges.has(edgeKey(parentId, c)));
     return {
       continuation: nonExplore[0] ?? null,
       regenerates: nonExplore.slice(1),
@@ -137,72 +163,130 @@ export function autoLayout(allNodes: ThoughtNode[], allEdges: ThoughtEdge[]): Th
   }
 
   // --- Pass 1: Assign columns ---
-  const nodeColumn = new Map<string, number>();
-  let nextColumn = 0;
   // Anchored chains live in VIRTUAL columns pinned to their material's x —
   // the grid formula never sees them, collision grouping still does.
   const VIRT_BASE = 100000;
-  let nextVirt = VIRT_BASE;
-  const colXOverride = new Map<number, number>();
-  const colX = (col: number) => colXOverride.get(col) ?? col * (NODE_WIDTH + H_GAP);
 
-  function assignColumns(nodeId: string, col: number) {
-    if (nodeColumn.has(nodeId)) return;
-    nodeColumn.set(nodeId, col);
+  function assignAllColumns(claimant: Map<string, string>) {
+    const nodeColumn = new Map<string, number>();
+    let nextColumn = 0;
+    let nextVirt = VIRT_BASE;
+    const colXOverride = new Map<number, number>();
+    const colX = (col: number) => colXOverride.get(col) ?? col * (NODE_WIDTH + H_GAP);
 
-    const { continuation, regenerates, explores } = classifyChildren(nodeId);
+    function assignColumns(nodeId: string, col: number) {
+      if (nodeColumn.has(nodeId)) return;
+      nodeColumn.set(nodeId, col);
 
-    // Continuation inherits same column
-    if (continuation) {
-      assignColumns(continuation, col);
-    }
+      const { continuation, regenerates, explores } = classifyChildren(nodeId, claimant);
 
-    // Regenerate siblings: columns immediately adjacent (col+1, col+2, ...).
-    // On an ANCHORED chain (virtual column) the sibling must take a fresh
-    // virtual column pinned beside the chain — arithmetic on a virtual
-    // column id would land in the grid formula at x ≈ 62 million, and
-    // feeding it into nextColumn would catapult every later root after it.
-    for (let i = 0; i < regenerates.length; i++) {
-      let regenCol: number;
-      if (col >= VIRT_BASE) {
-        regenCol = nextVirt++;
-        colXOverride.set(regenCol, colX(col) + (i + 1) * (NODE_WIDTH + H_GAP));
-      } else {
-        regenCol = col + 1 + i;
-        nextColumn = Math.max(nextColumn, regenCol + 1);
+      if (continuation) assignColumns(continuation, col);
+
+      // Regenerate siblings: columns immediately adjacent (col+1, col+2, ...).
+      // On an ANCHORED chain (virtual column) the sibling must take a fresh
+      // virtual column pinned beside the chain — arithmetic on a virtual
+      // column id would land in the grid formula at x ≈ 62 million, and
+      // feeding it into nextColumn would catapult every later root after it.
+      for (let i = 0; i < regenerates.length; i++) {
+        let regenCol: number;
+        if (col >= VIRT_BASE) {
+          regenCol = nextVirt++;
+          colXOverride.set(regenCol, colX(col) + (i + 1) * (NODE_WIDTH + H_GAP));
+        } else {
+          regenCol = col + 1 + i;
+          nextColumn = Math.max(nextColumn, regenCol + 1);
+        }
+        assignColumns(regenerates[i], regenCol);
       }
-      assignColumns(regenerates[i], regenCol);
+
+      // Explore branches: after all regenerate columns (anchored chains keep
+      // them beside the chain too, past the sibling columns)
+      let exploreOffset = 0;
+      for (const ec of explores) {
+        let exploreCol: number;
+        if (col >= VIRT_BASE) {
+          exploreCol = nextVirt++;
+          colXOverride.set(exploreCol, colX(col) + (regenerates.length + 1 + exploreOffset) * (NODE_WIDTH + H_GAP));
+          exploreOffset++;
+        } else {
+          exploreCol = nextColumn;
+          nextColumn++;
+        }
+        assignColumns(ec, exploreCol);
+      }
     }
 
-    // Explore branches: after all regenerate columns (anchored chains keep
-    // them beside the chain too, past the sibling columns)
-    let exploreOffset = 0;
-    for (const ec of explores) {
-      let exploreCol: number;
-      if (col >= VIRT_BASE) {
-        exploreCol = nextVirt++;
-        colXOverride.set(exploreCol, colX(col) + (regenerates.length + 1 + exploreOffset) * (NODE_WIDTH + H_GAP));
-        exploreOffset++;
+    for (const root of roots) {
+      const anchor = materialAnchors.get(root.id);
+      if (anchor) {
+        const virtCol = nextVirt++;
+        colXOverride.set(virtCol, anchor.x);
+        assignColumns(root.id, virtCol);
       } else {
-        exploreCol = nextColumn;
+        const rootCol = nextColumn;
         nextColumn++;
+        assignColumns(root.id, rootCol);
       }
-      assignColumns(ec, exploreCol);
     }
+
+    // A claimant sitting on a chain the walk never reaches would strand the
+    // merge with no column at all. Fall back to the median parent that DID get
+    // one, and repeat: placing one merge can unlock another below it.
+    for (let guard = 0; guard < nodes.length; guard++) {
+      let progressed = false;
+      for (const node of nodes) {
+        if (nodeColumn.has(node.id)) continue;
+        const cols = (structuralParents.get(node.id) || [])
+          .map((p) => nodeColumn.get(p))
+          .filter((c): c is number => c !== undefined)
+          .sort((a, b) => a - b);
+        if (!cols.length) continue;
+        assignColumns(node.id, cols[Math.floor((cols.length - 1) / 2)]);
+        progressed = true;
+      }
+      if (!progressed) break;
+    }
+
+    return { nodeColumn, colX };
   }
 
-  for (const root of roots) {
-    const anchor = materialAnchors.get(root.id);
-    if (anchor) {
-      const virtCol = nextVirt++;
-      colXOverride.set(virtCol, anchor.x);
-      assignColumns(root.id, virtCol);
-    } else {
-      const rootCol = nextColumn;
-      nextColumn++;
-      assignColumns(root.id, rootCol);
-    }
+  // ── Which parent owns a merge ──
+  // A node with several parents used to inherit the column of whichever parent
+  // the walk reached first, so the synthesis landed under one arbitrary source
+  // while the rest of its reading reached across the canvas.
+  //
+  // The middle parent should own it instead — but "middle" means middle COLUMN,
+  // and columns are what this pass is computing. So compute them once with
+  // nobody claiming anything, read the answer off that provisional run, and
+  // lay out again. Deriving the claimant from a node's position in the input
+  // array instead would be cheaper and wrong: the same graph handed over in a
+  // different order would lay out differently, which is the very instability
+  // this is meant to remove.
+  const provisional = assignAllColumns(new Map());
+  const claimant = new Map<string, string>();
+  for (const [child, ps] of structuralParents) {
+    if (ps.length < 2) continue;
+    const known = ps.filter((p) => provisional.nodeColumn.has(p));
+    // Only a parent this node CONTINUES from can own its column; one that
+    // explored it out is meant to stand beside it, and handing it the claim
+    // would drag the node out of the chain it actually continues. Explore
+    // parents are candidates only when there is no plain one.
+    const continued = known.filter((p) => !exploreEdges.has(edgeKey(p, child)));
+    const pool = continued.length ? continued : known;
+    if (!pool.length) continue;
+    // Rank by where a column SITS, never by its id. A chain grown from
+    // material is pinned to the document it came from and gets its id handed
+    // out in traversal order, so the ids carry no left-to-right meaning at
+    // all; only colX knows where the parent really is.
+    const ranked = [...pool].sort(
+      (a, b) =>
+        provisional.colX(provisional.nodeColumn.get(a)!) -
+          provisional.colX(provisional.nodeColumn.get(b)!) ||
+        (a < b ? -1 : a > b ? 1 : 0)
+    );
+    claimant.set(child, ranked[Math.floor((ranked.length - 1) / 2)]);
   }
+  const { nodeColumn, colX } = assignAllColumns(claimant);
 
   // --- Pass 2: Vertical positioning ---
   const nodeHeightMap = new Map<string, number>();
@@ -229,7 +313,7 @@ export function autoLayout(allNodes: ThoughtNode[], allEdges: ThoughtEdge[]): Th
     const parentPos = positioned.get(current)!;
     const parentHeight = nodeHeightMap.get(current) || 220;
 
-    const { continuation, regenerates, explores } = classifyChildren(current);
+    const { continuation, regenerates, explores } = classifyChildren(current, claimant);
 
     if (continuation && !visited.has(continuation)) {
       visited.add(continuation);
@@ -267,11 +351,74 @@ export function autoLayout(allNodes: ThoughtNode[], allEdges: ThoughtEdge[]): Th
     }
   }
 
+  // Same story for y: a merge reached only through its claimant may still be
+  // unplaced. Sit it below the lowest parent that was placed, so the arrow
+  // keeps pointing downward instead of the node collapsing to the origin.
+  for (let guard = 0; guard < nodes.length; guard++) {
+    let progressed = false;
+    for (const node of nodes) {
+      if (positioned.has(node.id)) continue;
+      const ps = (structuralParents.get(node.id) || []).filter((p) => positioned.has(p));
+      if (!ps.length) continue;
+      const bottom = Math.max(
+        ...ps.map((p) => positioned.get(p)!.y + (nodeHeightMap.get(p) || 220))
+      );
+      positioned.set(node.id, { x: colX(nodeColumn.get(node.id) ?? 0), y: bottom + V_GAP });
+      progressed = true;
+    }
+    if (!progressed) break;
+  }
+
   // Handle any orphan nodes (shouldn't happen, but safety)
   for (const node of nodes) {
     if (!positioned.has(node.id)) {
       positioned.set(node.id, { x: 0, y: 0 });
     }
+  }
+
+  // ── A merge clears every parent it reads ──
+  // Pass 2 hands a node its y from the single parent that walked to it, so a
+  // synthesis could sit level with — or above — the other sources feeding it
+  // and the arrow pointed back up the canvas. Whichever parent is chosen, the
+  // node belongs below the LOWEST one. Only merges need this (a single-parent
+  // chain is already correct by construction), and explore branches are
+  // exempt: they are meant to sit alongside their parent, not beneath it.
+  for (let pass = 0; pass < 5; pass++) {
+    let moved = false;
+    for (const node of nodes) {
+      const pos = positioned.get(node.id);
+      if (!pos) continue;
+      const all = (structuralParents.get(node.id) || []).filter((p) => positioned.has(p));
+      if (all.length < 2) continue;
+      // Two rules, one for each kind of arrow into this node. A parent it
+      // CONTINUES from must be cleared entirely. A parent that EXPLORED it out
+      // is meant to stand beside it — no clearance owed, but the child must
+      // still never float above that parent's top edge.
+      const continued = all.filter((p) => !exploreEdges.has(`${p}\u0000${node.id}`));
+      const explored = all.filter((p) => exploreEdges.has(`${p}\u0000${node.id}`));
+      let floor = -Infinity;
+      for (const p of continued) {
+        floor = Math.max(floor, positioned.get(p)!.y + (nodeHeightMap.get(p) || 220) + V_GAP);
+      }
+      for (const p of explored) {
+        floor = Math.max(floor, positioned.get(p)!.y);
+      }
+      if (floor > -Infinity && pos.y < floor) {
+        const delta = floor - pos.y;
+        pos.y = floor;
+        // The whole subtree travels with it, not only the part sharing this
+        // column. An explore branch is given a column of its own, so a
+        // column-restricted shift left it where it was and the child came to
+        // rest above the parent that spawned it. Dedupe first: a descendant
+        // reachable by two paths must not be moved twice.
+        for (const dId of new Set(getDescendantIds(node.id, structuralEdges))) {
+          const dPos = positioned.get(dId);
+          if (dPos) dPos.y += delta;
+        }
+        moved = true;
+      }
+    }
+    if (!moved) break;
   }
 
   // --- Pass 3: Collision resolution ---
@@ -304,13 +451,13 @@ export function autoLayout(allNodes: ThoughtNode[], allEdges: ThoughtEdge[]): Th
           currPos.y = minY;
           moved = true;
 
-          // Push all descendants down too (within same column)
-          const descIds = getDescendantIds(currId, structuralEdges);
-          for (const dId of descIds) {
+          // Push all descendants down too. Not only the ones sharing this
+          // column: an explore branch is given a column of its own, and
+          // leaving it behind stranded a child above the parent it came from.
+          // Dedupe — a descendant reachable by two paths moves once.
+          for (const dId of new Set(getDescendantIds(currId, structuralEdges))) {
             const dPos = positioned.get(dId);
-            if (dPos && nodeColumn.get(dId) === nodeColumn.get(currId)) {
-              dPos.y += delta;
-            }
+            if (dPos) dPos.y += delta;
           }
         }
       }


### PR DESCRIPTION
Closes #19.

## What changed

Tidy layout now places a node that has several parents among those parents,
instead of under whichever one the walk happened to reach first.

Four changes in `src/lib/layout.ts`, one cause:

1. **The median parent claims a merge.** The column claim was first-come, so it
   was decided by the order the arrows arrived in. "Median" means median
   *column*, and columns are what the pass computes — so columns are now
   computed twice: once with nobody claiming anything (today's behaviour), then
   again with each merge claimed by the parent standing in the median of them.
   Parents are ranked by `colX`, not by column id: a material-anchored chain is
   pinned to the document it grew from and takes its id in traversal order, so
   ids carry no left-to-right meaning. Only a parent the node *continues* from
   may claim it; a parent that explored it out stands beside it.
2. **A merge clears every parent it continues from**, not just the one that
   placed it — otherwise it rests level with a source it has not passed and the
   arrow points back up the canvas. An explore edge instead only requires the
   child never float above that parent's top.
3. **A chain grown from material starts at the centroid of its documents.** The
   anchor took x from the *lowest* material, a vertical criterion answering a
   horizontal question, so the chain parked under one arbitrary document.
4. **A moved node takes its whole subtree with it.** Both the new pass and the
   existing collision pass shifted only descendants sharing a column, and an
   explore branch gets a column of its own — so it stayed behind and ended up
   above the parent that spawned it. Descendants are deduplicated so one
   reachable by two paths moves once.

No UI copy, no data format, no API change. Content nodes are still never moved.

## Why

`autoLayout` is a column tree and is good at tree-shaped canvases — on the 160
benchmark canvases it already produces zero crossings, zero backward edges and
zero overlaps. On a DAG it flattens to a spanning tree in three places, so for a
node with N parents only one edge decides where it sits and the other N−1 become
long reaching arcs. Two consequences are measurable rather than aesthetic:
arrows that point back up the canvas, and layouts that change with input order.

## Evidence

A 26-node canvas whose merges read 8 sources and 6:

| | before | after |
|---|---|---|
| arrow-order violations | 2 | **0** |
| edge crossings | 5 | **1** |
| total edge length | 39,521px | **28,259px** (−29%) |
| longest horizontal run | 8,232px | **6,468px** (−21%) |
| node overlaps | 0 | 0 |

Non-regression across `benchmark/canvases/inputs/` (160 canvases):

| | main | this branch |
|---|---|---|
| crossings / backward / overlaps | 0 / 0 / 0 | 0 / 0 / 0 |
| total edge length | 75,507px | 73,977px (−2%) |

Generated graphs: 400 random DAGs carrying merges, explore branches, cross-links
and collapsed nodes, checked per edge against the arrow-order rules and for node
overlap. 258 that violated those rules on `main` are clean here, and **none
regress**.

Order stability: 200 graphs, each laid out from three orderings of the identical
graph. Layouts that vary with ordering fall from **70/200 on `main` to 27/200**.

Materials: a chain reading 5 documents spread across x=0..3600 started at x=3540,
the far right edge; it now starts at x=1740, among them.

Platform: layout consumes `measured` heights, which differ by OS through font
metrics and DPI. Scaling every node height 0.7×–2× leaves all invariants intact
on both corpora.

## Validation

The repo has no CI on pull requests, so this was run locally:

- [x] `npm run build` — passes
- [x] `npm run smoke` — SMOKE PASS
- [x] `npm run test:layout` — 7/7 (new; see below)
- [x] ESLint on the changed files — clean. Repo-wide `npm run lint` reports 17
      pre-existing errors; every file they occur in is byte-identical to `main`,
      so the count is unchanged by this PR.
- [x] `git diff --check` — clean
- [x] Tests added — `scripts/test-layout.mjs`, wired to `npm run test:layout`.
      **Five of its seven cases fail against `main`.** It needs no new
      dependency: it bundles `layout.ts` for node the way
      `benchmark/tools/build-bundle.sh` already bundles product code, because
      `src/lib/constants.ts` reads `import.meta.env` at module load and plain
      `node` therefore cannot import it. If you would rather have `vitest`, or
      no committed tests, say so and I will change it — I did not want to add a
      test framework to your repo uninvited.
- [x] No UI copy changed, so `en.ts` / `zh.ts` are untouched.
- [x] No data, backup, privacy or security surface touched.

## Contribution declaration

- [x] I certify that I wrote this contribution or otherwise have the right to submit it.
- [x] I agree that the contribution is licensed under the repository's MIT License.
- [x] I have disclosed third-party code, assets, data, or licensing restrictions.
- [x] Disclosed: developed with AI assistance (Claude) and reviewed by me.
      Findings from four automated review rounds are folded in.

## Known limitations

- Canvases whose sources are **interleaved** in creation order still cross. That
  needs column *ordering*, a separate lever not attempted here.
- A node that continues a chain **and** reads documents is unaffected: it
  inherits the chain's column, and content-node edges are stripped before the
  column tree is built, so its documents cannot pull it.
- Change 4 also repairs the pre-existing column-restricted shift in the
  collision pass, because the new pass would otherwise trigger it in cases it
  previously missed. That is arguably a second problem — happy to split it,
  though separating them leaves a knowingly-broken intermediate state.
