### PR TITLE
dsh build: run tsc/vite/esbuild through Node so Windows builds too

### DIFF
--- a/dsh/README.md
+++ b/dsh/README.md
@@ -112,6 +112,13 @@ dsh plugin --profile web add /abs/path/to/thoughtdag/dsh
 # 3. restart the profile's web app; open the view switch in the GUI
 ```
 
+The script drives `tsc`, `vite` and `esbuild` through Node directly, so the
+same code path builds on Windows, macOS and Linux. Always run it as
+`npm run dsh:build` instead of passing the flags through Git Bash by hand:
+MSYS path conversion rewrites `--base=/thoughtdag/` into a Git-install path,
+which bakes a broken base into `dist-app` — every asset request then falls
+through to the SPA fallback HTML and the canvas mounts as a blank white page.
+
 While developing, the profile keeps a pnpm *link* to this directory, so edits
 to `lib/` apply on the next restart without reinstalling.
 

--- a/dsh/scripts/build.mjs
+++ b/dsh/scripts/build.mjs
@@ -23,7 +23,13 @@ rmSync(tmp, { recursive: true, force: true })
 // this host, which answers them on the harness's providers.
 // VITE_DSH_BRIDGE tells the SPA where the plugin's session bridge answers, so
 // it installs the harness-backed window.desktopSessions at boot
-execFileSync('npm', ['run', 'build', '--', '--base=/thoughtdag/', '--outDir=' + tmp], { cwd: repo, stdio: 'inherit', env: { ...process.env, VITE_DSH_BRIDGE: '/thoughtdag/api', VITE_API_BASE: '/thoughtdag' } })
+// The type gate the root `npm run build` has, then vite itself. Every tool is
+// run as a node script through this process's own node binary: execFileSync
+// cannot spawn `npm` (a .cmd needing a shell on Windows) nor the extensionless
+// .bin shims, while a JS entry takes argv verbatim — no shell, no quoting, one
+// code path on every platform.
+execFileSync(process.execPath, [resolve(repo, 'node_modules/typescript/bin/tsc'), '-b'], { cwd: repo, stdio: 'inherit' })
+execFileSync(process.execPath, [resolve(repo, 'node_modules/vite/bin/vite.js'), 'build', '--base=/thoughtdag/', '--outDir=' + tmp], { cwd: repo, stdio: 'inherit', env: { ...process.env, VITE_DSH_BRIDGE: '/thoughtdag/api', VITE_API_BASE: '/thoughtdag' } })
 // keep only what the embedded SPA needs; landing-page covers are not served
 rmSync(resolve(tmp, 'covers'), { recursive: true, force: true })
 // the tutorial's gifs stay: a first-time visitor inside the harness sees the same walkthrough
@@ -35,9 +41,8 @@ console.log('plugin SPA written to', outDir)
 
 // The why layer: the CLI's library, bundled for the host (Node), so the plugin
 // registers the same four questions as native harness tools and a /why command
-const esbuild = resolve(repo, 'node_modules/.bin/esbuild')
 const whyOut = resolve(__dirname, '../lib/why.mjs')
-execFileSync(esbuild, [resolve(repo, 'cli/src/lib.ts'), '--bundle', '--platform=node', '--format=esm', '--target=node22', '--define:import.meta.env={}', '--outfile=' + whyOut, '--log-level=warning'], { stdio: 'inherit' })
+execFileSync(process.execPath, [resolve(repo, 'node_modules/esbuild/bin/esbuild'), resolve(repo, 'cli/src/lib.ts'), '--bundle', '--platform=node', '--format=esm', '--target=node22', '--define:import.meta.env={}', '--outfile=' + whyOut, '--log-level=warning'], { stdio: 'inherit' })
 console.log('why layer written to', whyOut)
 
 // The shared agent runtime (plain Node): the host serves it over HTTP so the

--- a/dsh/scripts/build.mjs
+++ b/dsh/scripts/build.mjs
@@ -4,6 +4,7 @@
 //   node scripts/build.mjs [thoughtdag-repo] [outDir]   (from dsh/: node scripts/build.mjs ..)
 //   npm run dsh:build                                  (from the repo root)
 import { execFileSync } from 'node:child_process'
+import { createRequire } from 'node:module'
 import { mkdirSync, rmSync, cpSync, existsSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -23,11 +24,11 @@ rmSync(tmp, { recursive: true, force: true })
 // this host, which answers them on the harness's providers.
 // VITE_DSH_BRIDGE tells the SPA where the plugin's session bridge answers, so
 // it installs the harness-backed window.desktopSessions at boot
-// The type gate the root `npm run build` has, then vite itself. Every tool is
-// run as a node script through this process's own node binary: execFileSync
-// cannot spawn `npm` (a .cmd needing a shell on Windows) nor the extensionless
-// .bin shims, while a JS entry takes argv verbatim — no shell, no quoting, one
-// code path on every platform.
+// The type gate the root `npm run build` has, then vite itself. tsc and vite
+// ship pure-JS entries no installer ever touches, so both run as node scripts
+// through this process's own node binary: execFileSync cannot spawn `npm` (a
+// .cmd needing a shell on Windows) nor the extensionless .bin shims, while a
+// JS entry takes argv verbatim — no shell, no quoting, one code path.
 execFileSync(process.execPath, [resolve(repo, 'node_modules/typescript/bin/tsc'), '-b'], { cwd: repo, stdio: 'inherit' })
 execFileSync(process.execPath, [resolve(repo, 'node_modules/vite/bin/vite.js'), 'build', '--base=/thoughtdag/', '--outDir=' + tmp], { cwd: repo, stdio: 'inherit', env: { ...process.env, VITE_DSH_BRIDGE: '/thoughtdag/api', VITE_API_BASE: '/thoughtdag' } })
 // keep only what the embedded SPA needs; landing-page covers are not served
@@ -41,8 +42,22 @@ console.log('plugin SPA written to', outDir)
 
 // The why layer: the CLI's library, bundled for the host (Node), so the plugin
 // registers the same four questions as native harness tools and a /why command
+// esbuild is the one tool that cannot run as a node script: its installer
+// overwrites bin/esbuild with the native binary on macOS and Linux (the JS
+// shim survives only on Windows), so node on it dies with a SyntaxError. Its
+// JS API locates the platform binary itself — the same flags as the root
+// `cli:build`, resolved from the repo's own esbuild, still no shell anywhere.
 const whyOut = resolve(__dirname, '../lib/why.mjs')
-execFileSync(process.execPath, [resolve(repo, 'node_modules/esbuild/bin/esbuild'), resolve(repo, 'cli/src/lib.ts'), '--bundle', '--platform=node', '--format=esm', '--target=node22', '--define:import.meta.env={}', '--outfile=' + whyOut, '--log-level=warning'], { stdio: 'inherit' })
+await createRequire(resolve(repo, 'package.json'))('esbuild').build({
+  entryPoints: [resolve(repo, 'cli/src/lib.ts')],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  target: 'node22',
+  define: { 'import.meta.env': '{}' },
+  outfile: whyOut,
+  logLevel: 'warning',
+})
 console.log('why layer written to', whyOut)
 
 // The shared agent runtime (plain Node): the host serves it over HTTP so the


### PR DESCRIPTION
Fixes #24

Both `execFileSync` spawn targets in `dsh/scripts/build.mjs` were Unix-only: `npm` is `npm.cmd` on Windows (and a `.cmd` needs a shell since CVE-2024-27980), and the extensionless `.bin/esbuild` shim cannot be spawned either. This takes the shell-free road you asked for, with one code path on every platform:

- `node_modules/typescript/bin/tsc -b` — the same type gate the root `npm run build` has — runs first, through `process.execPath`
- `node_modules/vite/bin/vite.js build --base=/thoughtdag/ --outDir=…` runs next, with the same cwd and the same `VITE_DSH_BRIDGE` / `VITE_API_BASE` env as before
- `node_modules/esbuild/bin/esbuild` bundles the why layer the same way

No `shell:` anywhere, no `npm run`, no `.bin` shims: argv goes to a JS entry verbatim, so it never crosses `cmd.exe` and paths with spaces need no quoting — and there are no `process.platform` branches.

`dsh/README.md` also gains the requested build note: run `npm run dsh:build` rather than passing the flags through Git Bash by hand, because MSYS path conversion rewrites `--base=/thoughtdag/` into a Git-install path and the canvas mounts as a blank white page.

Verified on Windows 11 x64 / Node v22.22.0 (repo at 0c6d961):

- `npm run dsh:build` runs end-to-end: type gate → SPA (`dist-app/index.html` references `/thoughtdag/assets/…`) → why layer (`lib/why.mjs` imports cleanly as ESM) → agent runtime; covers dropped, tutorial gifs kept, temp dir cleaned
- a full build from a path containing spaces (junction with a space in it) produces the same correct base — no quoting involved anywhere
- `npm run lint` and the root `npm run build` still pass
- real-harness check: with the plugin installed from this tree (`link:` into a web profile), the host serves `/thoughtdag/` (200, `text/javascript` assets — not the SPA fallback HTML the broken base produces) and `/thoughtdag/api/disksessions` returns live JSON

macOS byte-for-byte parity is yours as offered; the commands per tool are unchanged apart from being invoked through node, so the outputs should match `npm run build` exactly.