### PR TITLE
Fix Harness child nodes losing DSH preset session state

### DIFF
--- a/dsh/lib/index.js
+++ b/dsh/lib/index.js
@@ -665,24 +665,33 @@ function installApprovalAnswerer(ctx) {
 }
 
 /** Run one question through the harness's agent loop, continuing a mirrored
- *  session, forking a ThoughtDAG parent session, or creating a fresh session.
- *  Report progress as SSE-style frames via `emit`; resolves when the turn ends. */
+ *  session, forking a dsh mirror at the parent's exact turn, or creating a
+ *  fresh session. Report progress as SSE-style frames via `emit`; resolves
+ *  when the turn ends. */
 async function runAgentTurn(ctx, body, emit, isClosed, { answerApprovals = true } = {}) {
   const { question, context } = compileForAgent(body)
-  // A mirrored DSH tail continues in place. Ordinary ThoughtDAG child nodes
-  // fork their parent's Harness session so durable preset state (for example
-  // promotion after a first tool/call) follows the branch while sibling
-  // branches remain isolated. Otherwise create a fresh session.
+  // A parent that is a current ledger tail continues in place. A historical
+  // dsh mirror forks at the exact turn named by its user-message id, so later
+  // turns (including sibling work) cannot leak into the branch. Otherwise a
+  // fresh session receives the compiled canvas context.
   const continueId = typeof body?.harness?.session === 'string' && body.harness.session ? body.harness.session : null
   const forkId = typeof body?.harness?.forkSession === 'string' && body.harness.forkSession ? body.harness.forkSession : null
-  let sessionId
+  const forkAnchor = typeof body?.harness?.forkAnchor === 'string' && body.harness.forkAnchor ? body.harness.forkAnchor : null
+  let sessionId = null
   let forkedFrom = null
   if (continueId && (liveSession(ctx, continueId) || (await eventsOfSession(ctx, continueId)) !== null)) {
     sessionId = continueId
-  } else if (forkId && (liveSession(ctx, forkId) || (await eventsOfSession(ctx, forkId)) !== null)) {
-    sessionId = (await ctx.sessionController.fork({ sessionId: forkId })).sessionId
-    forkedFrom = forkId
-  } else {
+  } else if (forkId && forkAnchor) {
+    const events = await eventsOfSession(ctx, forkId)
+    if (events !== null) {
+      const turn = turnsOf(events).find(t => t.userMessageId === forkAnchor)
+      if (!turn) throw new HttpError(400, 'no such fork anchor: ' + forkAnchor)
+      if (turn.endSeq === null) throw new HttpError(409, 'turn ' + turn.turn + ' is still open; a fork needs a completed turn')
+      sessionId = (await ctx.sessionController.fork({ sessionId: forkId, atSeq: turn.endSeq })).sessionId
+      forkedFrom = forkId
+    }
+  }
+  if (!sessionId) {
     const cwd = typeof body?.harness?.cwd === 'string' && body.harness.cwd ? { cwd: body.harness.cwd } : {}
     sessionId = (await ctx.sessionController.create({ ...cwd })).sessionId
   }

--- a/dsh/lib/index.js
+++ b/dsh/lib/index.js
@@ -664,21 +664,29 @@ function installApprovalAnswerer(ctx) {
   }, true)
 }
 
-/** Run one question through the harness's agent loop in a fresh session and
- *  report it as SSE-style frames via `emit`; resolves when the turn ends. */
+/** Run one question through the harness's agent loop, continuing a mirrored
+ *  session, forking a ThoughtDAG parent session, or creating a fresh session.
+ *  Report progress as SSE-style frames via `emit`; resolves when the turn ends. */
 async function runAgentTurn(ctx, body, emit, isClosed, { answerApprovals = true } = {}) {
   const { question, context } = compileForAgent(body)
-  // continue the session the canvas mirrors (a tail follow-up), else a fresh
-  // session in the requested working directory (the canvas's project)
+  // A mirrored DSH tail continues in place. Ordinary ThoughtDAG child nodes
+  // fork their parent's Harness session so durable preset state (for example
+  // promotion after a first tool/call) follows the branch while sibling
+  // branches remain isolated. Otherwise create a fresh session.
   const continueId = typeof body?.harness?.session === 'string' && body.harness.session ? body.harness.session : null
+  const forkId = typeof body?.harness?.forkSession === 'string' && body.harness.forkSession ? body.harness.forkSession : null
   let sessionId
+  let forkedFrom = null
   if (continueId && (liveSession(ctx, continueId) || (await eventsOfSession(ctx, continueId)) !== null)) {
     sessionId = continueId
+  } else if (forkId && (liveSession(ctx, forkId) || (await eventsOfSession(ctx, forkId)) !== null)) {
+    sessionId = (await ctx.sessionController.fork({ sessionId: forkId })).sessionId
+    forkedFrom = forkId
   } else {
     const cwd = typeof body?.harness?.cwd === 'string' && body.harness.cwd ? { cwd: body.harness.cwd } : {}
     sessionId = (await ctx.sessionController.create({ ...cwd })).sessionId
   }
-  emit({ harnessSession: sessionId, continued: sessionId === continueId })
+  emit({ harnessSession: sessionId, continued: sessionId === continueId, ...(forkedFrom ? { forkedFrom } : {}) })
   // a streaming caller can show and answer approvals; a one-shot caller
   // (/claude) cannot, so its requests fall through to the harness's own panel
   const turnEntry = { emit, isClosed, calls: new Map() }
@@ -724,7 +732,8 @@ async function runAgentTurn(ctx, body, emit, isClosed, { answerApprovals = true 
     }
   })
   try {
-    const injectContext = continueId && sessionId === continueId ? (typeof body?.harness?.extraContext === 'string' ? body.harness.extraContext : '') : context
+    const inheritsSessionContext = (continueId && sessionId === continueId) || forkedFrom
+    const injectContext = inheritsSessionContext ? (typeof body?.harness?.extraContext === 'string' ? body.harness.extraContext : '') : context
     if (injectContext) agent.inject({ id: 'td-' + randomUUID(), role: 'user', content: [{ type: 'text', text: injectContext }], source: SOURCE })
     const promptContent = [{ type: 'text', text: question }]
     for (const img of Array.isArray(body?.images) ? body.images : []) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -235,7 +235,7 @@ export async function llmCallStream(
       session it continues (a tail follow-up) — the harness's inside
       DeepSeek Harness, the desktop runtime's (Pi) in the app. Ignored by
       every model backend. */
-  harness?: { cwd?: string; session?: string; sessionPath?: string; forkEntryId?: string; nodeId?: string; continue?: boolean },
+  harness?: { cwd?: string; session?: string; forkSession?: string; sessionPath?: string; forkEntryId?: string; nodeId?: string; continue?: boolean },
 ): Promise<string> {
   // On the Workers deployment, OpenRouter models stream straight from the
   // browser — the proxy's CPU allowance can't survive big contexts + heavy

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -231,11 +231,10 @@ export async function llmCallStream(
   callbacks?: StreamCallbacks,
   toolPrefs?: ToolPrefs,
   modelOverride?: string,
-  /** Agent lanes only: which working directory the turn runs in, and which
-      session it continues (a tail follow-up) — the harness's inside
-      DeepSeek Harness, the desktop runtime's (Pi) in the app. Ignored by
-      every model backend. */
-  harness?: { cwd?: string; session?: string; forkSession?: string; sessionPath?: string; forkEntryId?: string; nodeId?: string; continue?: boolean },
+  /** Agent lanes only: which working directory the turn runs in, which
+      session it continues, or which DSH session+turn anchor it forks from.
+      The harness fields are ignored by every non-Harness backend. */
+  harness?: { cwd?: string; session?: string; forkSession?: string; forkAnchor?: string; sessionPath?: string; forkEntryId?: string; nodeId?: string; continue?: boolean },
 ): Promise<string> {
   // On the Workers deployment, OpenRouter models stream straight from the
   // browser — the proxy's CPU allowance can't survive big contexts + heavy

--- a/src/lib/atlas/dsh-bridge.ts
+++ b/src/lib/atlas/dsh-bridge.ts
@@ -314,14 +314,16 @@ async function activeCanvasCwd(): Promise<string | null> {
   } catch { return null; }
 }
 
+type HarnessRoute = { cwd?: string; session?: string; forkSession?: string; forkAnchor?: string };
+
 /** For the node about to generate: the harness routing for its request, or
- *  undefined when not embedded / not a harness-agent question. A question
- *  asked DIRECTLY off the mirrored session's current tail, with nothing else
- *  wired in, continues that session (a follow-up). A simple child of a
- *  ThoughtDAG-created Harness session forks that session, preserving durable
- *  agent/preset state while keeping sibling branches isolated. Richer wiring
- *  gets a fresh session carrying the compiled context. */
-export async function harnessOutbound(nodeId: string, model: string | undefined): Promise<{ cwd?: string; session?: string; forkSession?: string } | undefined> {
+ *  undefined when not embedded / not a harness-agent question. A simple
+ *  child continues when its parent is the tail of ANY dsh ledger entry
+ *  (main, chapter or branch). A dsh mirror parent that is not a current tail
+ *  forks at that parent's own turn, identified by its user-message id. Any
+ *  richer wiring, or a parent without an exact turn anchor, gets a fresh
+ *  session carrying the compiled canvas context. */
+export async function harnessOutbound(nodeId: string, model: string | undefined): Promise<HarnessRoute | undefined> {
   if (!window.desktopSessions || !isHarnessAgentModel(model)) return undefined;
   const cwd = (await activeCanvasCwd()) ?? currentSession?.cwd ?? undefined;
   try {
@@ -333,29 +335,29 @@ export async function harnessOutbound(nodeId: string, model: string | undefined)
     const incoming = edges.filter((e) => e.target === nodeId);
     if (incoming.length === 1) {
       const parentId = incoming[0].source;
-      // Preserve the existing live-mirror behavior: a direct follow-up from
-      // the imported DSH session's current tail continues in place.
-      if (ss && ss.runner === 'dsh' && parentId === ss.tailNodeId) {
-        return { ...(cwd ? { cwd } : {}), session: ss.sessionId };
+      // The live mirror may file a harness-created session under chapters or
+      // branches rather than the placeholder main entry. Search the complete
+      // ledger exactly as agentOutbound does for Pi/Codex/Claude Code.
+      const entries = ss
+        ? [ss, ...(ss.chapters ?? []), ...(ss.branches ?? [])].filter((e) => e.runner === 'dsh' && e.sessionId)
+        : [];
+      const tailEntry = entries.find((e) => e.tailNodeId === parentId);
+      if (tailEntry) {
+        return { ...(cwd ? { cwd } : {}), session: tailEntry.sessionId };
       }
+
+      // A historical/non-tail dsh mirror must fork at the parent's OWN turn,
+      // never at the session's latest turn: otherwise a sibling or later turn
+      // can leak into this branch. itemIds[0] is the user's message id for the
+      // mirrored turn and the host resolves it to that turn's endSeq.
       const parent = nodes.find((n) => n.id === parentId);
-      const parentSession = parent?.data.importSource?.runner === 'dsh'
-        ? parent.data.importSource.sessionId
-        : undefined;
-      if (parentSession) {
-        // Imported historical nodes may represent an earlier turn in a longer
-        // subscribed session. Without an exact turn anchor, forking that
-        // session's latest turn could leak later history. Sessions created by
-        // ThoughtDAG itself are not ledger subscriptions, so their last turn is
-        // exactly the parent node and is safe to fork.
-        const subscribed = new Set([
-          ss?.sessionId,
-          ...(ss?.chapters ?? []).map((c) => c.sessionId),
-          ...(ss?.branches ?? []).map((b) => b.sessionId),
-        ].filter((id): id is string => !!id));
-        if (!subscribed.has(parentSession)) {
-          return { ...(cwd ? { cwd } : {}), forkSession: parentSession };
-        }
+      const source = parent?.data.importSource;
+      if (source?.runner === 'dsh' && source.sessionId && source.itemIds?.[0]) {
+        return {
+          ...(cwd ? { cwd } : {}),
+          forkSession: source.sessionId,
+          forkAnchor: source.itemIds[0],
+        };
       }
     }
   } catch { /* store not ready — fall through to a fresh session */ }
@@ -363,7 +365,6 @@ export async function harnessOutbound(nodeId: string, model: string | undefined)
 }
 
 type HarnessTurnRef = { session: string; turn: number | null; userMessageId: string | null; seq: number | null };
-type HarnessRoute = { cwd?: string; session?: string; forkSession?: string };
 
 /** Provenance for a node that IS a dsh turn: runner, session, the person's
  *  message id (the deep-link and dedup key), the project it ran in. */

--- a/src/lib/atlas/dsh-bridge.ts
+++ b/src/lib/atlas/dsh-bridge.ts
@@ -317,22 +317,45 @@ async function activeCanvasCwd(): Promise<string | null> {
 /** For the node about to generate: the harness routing for its request, or
  *  undefined when not embedded / not a harness-agent question. A question
  *  asked DIRECTLY off the mirrored session's current tail, with nothing else
- *  wired in, continues that session (a follow-up); any richer wiring gets a
- *  fresh session carrying the compiled context. */
-export async function harnessOutbound(nodeId: string, model: string | undefined): Promise<{ cwd?: string; session?: string } | undefined> {
+ *  wired in, continues that session (a follow-up). A simple child of a
+ *  ThoughtDAG-created Harness session forks that session, preserving durable
+ *  agent/preset state while keeping sibling branches isolated. Richer wiring
+ *  gets a fresh session carrying the compiled context. */
+export async function harnessOutbound(nodeId: string, model: string | undefined): Promise<{ cwd?: string; session?: string; forkSession?: string } | undefined> {
   if (!window.desktopSessions || !isHarnessAgentModel(model)) return undefined;
   const cwd = (await activeCanvasCwd()) ?? currentSession?.cwd ?? undefined;
   try {
     const { useStore } = await import('../../store');
     const { useProjects } = await import('../../store/projects');
     const { projects, activeId } = useProjects.getState();
-    const meta = projects.find((p) => p.id === activeId);
-    const ss = meta?.sourceSession;
-    if (ss && ss.runner === 'dsh') {
-      const incoming = useStore.getState().edges.filter((e) => e.target === nodeId);
-      // exactly one parent, and it is the mirror's current tail → continue
-      if (incoming.length === 1 && incoming[0].source === ss.tailNodeId) {
+    const ss = projects.find((p) => p.id === activeId)?.sourceSession;
+    const { nodes, edges } = useStore.getState();
+    const incoming = edges.filter((e) => e.target === nodeId);
+    if (incoming.length === 1) {
+      const parentId = incoming[0].source;
+      // Preserve the existing live-mirror behavior: a direct follow-up from
+      // the imported DSH session's current tail continues in place.
+      if (ss && ss.runner === 'dsh' && parentId === ss.tailNodeId) {
         return { ...(cwd ? { cwd } : {}), session: ss.sessionId };
+      }
+      const parent = nodes.find((n) => n.id === parentId);
+      const parentSession = parent?.data.importSource?.runner === 'dsh'
+        ? parent.data.importSource.sessionId
+        : undefined;
+      if (parentSession) {
+        // Imported historical nodes may represent an earlier turn in a longer
+        // subscribed session. Without an exact turn anchor, forking that
+        // session's latest turn could leak later history. Sessions created by
+        // ThoughtDAG itself are not ledger subscriptions, so their last turn is
+        // exactly the parent node and is safe to fork.
+        const subscribed = new Set([
+          ss?.sessionId,
+          ...(ss?.chapters ?? []).map((c) => c.sessionId),
+          ...(ss?.branches ?? []).map((b) => b.sessionId),
+        ].filter((id): id is string => !!id));
+        if (!subscribed.has(parentSession)) {
+          return { ...(cwd ? { cwd } : {}), forkSession: parentSession };
+        }
       }
     }
   } catch { /* store not ready — fall through to a fresh session */ }
@@ -340,7 +363,7 @@ export async function harnessOutbound(nodeId: string, model: string | undefined)
 }
 
 type HarnessTurnRef = { session: string; turn: number | null; userMessageId: string | null; seq: number | null };
-type HarnessRoute = { cwd?: string; session?: string };
+type HarnessRoute = { cwd?: string; session?: string; forkSession?: string };
 
 /** Provenance for a node that IS a dsh turn: runner, session, the person's
  *  message id (the deep-link and dedup key), the project it ran in. */


### PR DESCRIPTION
## What this PR fixes

ThoughtDAG Harness-agent child nodes currently start a brand-new DSH Session unless they are a direct tail continuation of an imported DSH session. That means **session-scoped Agent preset state is reset at every ordinary DAG child node**.

A concrete example is a DSH preset such as `router-flash` that intentionally exposes a small bootstrap tool set on the first request, then promotes to the full tool catalog after the first durable `tool/call`. In normal DSH chat, that promotion persists because later turns stay in the same Session. In ThoughtDAG, the next child node used to call `sessionController.create()` again, so the child returned to the bootstrap state and lost access to tools such as `schedule_create`, `schedule_list`, `schedule_delete`, memory tools, MCP tools, etc. until it performed another bootstrap tool call.

This PR makes a simple ThoughtDAG child of a ThoughtDAG-created Harness session **fork the parent DSH Session** instead of creating a fresh one.

## Root cause

The existing bridge only has two effective paths:

1. direct follow-up from the current imported DSH tail → continue the same Session;
2. everything else → create a fresh Session.

ThoughtDAG already stamps each Harness-generated node with its actual DSH `sessionId`, but that provenance was not used when generating an ordinary child node.

## What changes

- `src/lib/atlas/dsh-bridge.ts`
  - detects a single parent node backed by a ThoughtDAG-created DSH Harness Session;
  - returns `forkSession` for that parent;
  - preserves the existing direct-tail `session` continuation behavior;
  - deliberately does **not** fork historical imported/subscribed DSH sessions without an exact turn anchor, because forking their latest turn could leak later history.
- `src/lib/api.ts`
  - carries `forkSession` through the Harness request shape.
- `dsh/lib/index.js`
  - resolves `forkSession` with DSH's native `sessionController.fork()`;
  - preserves the inherited Session event log and Agent preset state while giving the child its own Session id;
  - treats a fork like a continuation for context injection, avoiding duplication of the already-inherited Canvas history.

## Why fork instead of continue

Reusing one DSH Session for every DAG child would break DAG semantics. Given:

```text
    A
   / \
  B   C
```

if both B and C continued A's same live Session, whichever branch ran second could see the first sibling's history even though there is no graph edge between them.

DSH's native `fork()` is the right primitive here: B and C each inherit A's completed-turn prefix and durable preset state, but receive independent Session ids and stay isolated from each other.

## Behavior preserved

- A direct follow-up from the current imported DSH session tail still continues that exact Session.
- Multi-parent / richer-wiring nodes still get a fresh Session carrying the compiled Canvas context.
- Historical imported DSH nodes are not blindly forked from the session's latest turn when the exact source turn is unknown.

## Runtime verification

Verified against `dsh-thoughtdag 0.4.11` with a real DSH Web profile.

Observed parent Session behavior:

```text
request/header -> 4 tools
actual tool/call -> read/pwsh
next request/header -> 199 tools
```

The 199-tool catalog included:

```text
schedule_create
schedule_list
schedule_delete
memory
skill_manage
dtodo
```

After forking that promoted parent Session, the new child Session retained `agentPreset: router-flash`, recorded the correct `parentSession`, and its first new request inherited the full catalog.

A functional test then produced a real DSH tool invocation:

```text
tool/call -> schedule_list
result -> []
```

So this is not only a UI/model self-report change: the DSH tool is actually callable in the forked ThoughtDAG child Session.

One caveat discovered during verification: the model may still *say* it only has the original four bootstrap tools because of prior conversational context, even when the request header already contains all 199 tool schemas. That self-report issue is separate from the session-continuity bug fixed here; direct `schedule_list` invocation succeeds.

Fixes #28
