### PR TITLE
修复了dsh中‘如何使用’中教程图片显示错误的bug

### DIFF
--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -214,7 +214,7 @@ export default function Tutorial() {
               <div key={n} className="bg-surface border border-line/70 rounded-xl p-4 flex flex-col animate-fade-in">
                 <div className="w-full aspect-[120/72] bg-card rounded-lg border border-line/60 mb-3 overflow-hidden">
                   {GIF_STEPS[n]
-                    ? <img src={`/tutorial/${GIF_STEPS[n]}-${lang}.gif`} loading="lazy" alt="" className="w-full h-full object-cover" />
+                    ? <img src={`${import.meta.env.BASE_URL}tutorial/${GIF_STEPS[n]}-${lang}.gif`} loading="lazy" alt="" className="w-full h-full object-cover" />
                     : DIAGRAMS[n]}
                 </div>
                 <h3 className="text-[13px] font-semibold text-ink leading-snug">{t(`tutorial.step${n}.title` as Parameters<typeof t>[0])}</h3>


### PR DESCRIPTION
## What changed

<!-- Describe the user-visible behavior and the scope of this pull request. -->
src/components/Tutorial.tsx第217行固定图片地址修改为import.meta.env.BASE_URL前缀
```diff
- ? <img src={`/tutorial/${GIF_STEPS[n]}-${lang}.gif`} loading="lazy" alt="" className="w-full h-full object-cover" />
+ ? <img src={`${import.meta.env.BASE_URL}tutorial/${GIF_STEPS[n]}-${lang}.gif`} loading="lazy" alt="" className="w-full h-full object-cover" />
```

## Why

<!-- What problem does this solve? Link the related issue for a significant change. -->
教程弹窗里那几张 gif 的图片地址在代码里写死成了根路径 /tutorial/...，没有跟着 Vite 的 base 配置走；dsh 把整个应用打包成挂在 /thoughtdag/ 前缀下（base=/thoughtdag/），这个写死的路径就变成了一个不存在的地址，图片加载不出来。改成用 import.meta.env.BASE_URL 拼接后，不管打包成挂在根路径还是子路径下，图片地址都能自动跟着调整。

## Evidence

<!-- Add screenshots, a recording, tests, or reproduction steps when applicable. -->
<img width="1512" height="982" alt="Screenshot 2026-09-11 at 9 02 21 PM" src="https://github.com/user-attachments/assets/915f818c-960a-4560-836b-81e0acf1a3d5" />

<p align="center">
  <strong>修改前</strong>
</p>
<img width="1512" height="982" alt="Screenshot 2026-09-11 at 9 36 40 PM" src="https://github.com/user-attachments/assets/30cc5af4-e907-4a6c-a3e0-d23ea47b167f" />

<p align="center">
  <strong>修改后</strong>
</p>


## Validation

本地客户端及dsh端验证均无误

## Contribution declaration

By submitting this pull request:

- [x] I certify that I wrote this contribution or otherwise have the right to submit it.
- [x] I agree that the contribution is licensed under the repository's MIT License.
- [x] I have disclosed third-party code, assets, data, or licensing restrictions.
- [x] I have disclosed substantial AI-generated or AI-transformed material, or this does not apply.
