### PR TITLE
fix(layout): keep frames with members after auto layout (#32)

### DIFF
--- a/scripts/test-layout.mjs
+++ b/scripts/test-layout.mjs
@@ -46,8 +46,15 @@ const th = (id, over = {}) => ({
   },
 });
 const file = (id, x) => ({ ...th(id, { stepKind: 'file' }), position: { x, y: 0 }, measured: { width: 120, height: 120 } });
+const frame = (id, x, y, width, height, frameCarry = true) => ({
+  ...th(id, { stepKind: 'frame', frameCarry }), position: { x, y }, width, height, zIndex: -1,
+});
+const placed = (node, x, y, width = 520, height = 120) => ({
+  ...node, position: { x, y }, measured: { width, height },
+});
 const ed = (s, t, data) => ({ id: `${s}->${t}`, source: s, target: t, ...(data ? { data } : {}) });
 const xOf = (laid, id) => laid.find((n) => n.id === id).position.x;
+const nodeOf = (laid, id) => laid.find((n) => n.id === id);
 
 // Every arrow-order and overlap rule, checked per edge.
 function violations(laid, edges) {
@@ -128,6 +135,73 @@ test('a chain reading several documents hangs from the lowest of them', () => {
   const edges = ['f0', 'f1', 'f2', 'f3', 'f4'].map((f) => ed(f, 'synth'));
   const x = xOf(autoLayout(nodes, edges), 'synth');
   assert(Math.abs(x - (2700 - 60)) < 1, `synthesis at ${x}, not under the lowest document f3`);
+});
+
+test('a linked frame re-wraps the members it contained before layout', () => {
+  const nodes = [
+    frame('frame', 0, 400, 700, 900),
+    placed(th('root'), 100, 500, 520, 260),
+    placed(th('child'), 100, 900, 520, 260),
+  ];
+  const laid = autoLayout(nodes, [ed('root', 'child')]);
+  const f = nodeOf(laid, 'frame'), root = nodeOf(laid, 'root'), child = nodeOf(laid, 'child');
+  const minX = Math.min(root.position.x, child.position.x);
+  const maxX = Math.max(root.position.x + 520, child.position.x + 520);
+  const minY = Math.min(root.position.y, child.position.y);
+  const maxY = Math.max(root.position.y + nodeHeight(root), child.position.y + nodeHeight(child));
+  assert(f.position.y < 0, `frame stayed near its old y=${f.position.y}`);
+  assert(f.position.x < minX && f.position.y < minY, 'frame does not leave padding above/left of members');
+  assert(f.position.x + f.width > maxX && f.position.y + f.height > maxY, 'frame does not enclose laid-out members');
+});
+
+test('an unlinked frame is untouched by auto layout', () => {
+  const original = frame('frame', 0, 400, 700, 900, false);
+  const laid = autoLayout([
+    original,
+    placed(th('root'), 100, 500),
+    placed(th('child'), 100, 900),
+  ], [ed('root', 'child')]);
+  const f = nodeOf(laid, 'frame');
+  assert(f.position.x === original.position.x && f.position.y === original.position.y, 'unlinked frame moved');
+  assert(f.width === original.width && f.height === original.height, 'unlinked frame resized');
+});
+
+test('a linked frame with no members is untouched by auto layout', () => {
+  const original = frame('empty', 2000, 2000, 700, 900);
+  const laid = autoLayout([original, placed(th('root'), 0, 0)], []);
+  const f = nodeOf(laid, 'empty');
+  assert(f.position.x === original.position.x && f.position.y === original.position.y, 'empty frame moved');
+  assert(f.width === original.width && f.height === original.height, 'empty frame resized');
+});
+
+test('nested frames re-wrap inner to outer with more room on the outer frame', () => {
+  const nodes = [
+    frame('outer', 0, 400, 760, 1050),
+    frame('inner', 50, 450, 660, 950),
+    placed(th('root'), 100, 500),
+    placed(th('child'), 100, 900),
+  ];
+  const laid = autoLayout(nodes, [ed('root', 'child')]);
+  const outer = nodeOf(laid, 'outer'), inner = nodeOf(laid, 'inner');
+  assert(outer.position.x < inner.position.x, 'outer frame does not have more left padding');
+  assert(outer.position.y < inner.position.y, 'outer frame does not have more top padding');
+  assert(outer.position.x + outer.width > inner.position.x + inner.width, 'outer frame does not have more right padding');
+  assert(outer.position.y + outer.height > inner.position.y + inner.height, 'outer frame does not have more bottom padding');
+});
+
+test('overlapping frames can share a member and both still follow it', () => {
+  const nodes = [
+    frame('leftFrame', 0, 400, 650, 700),
+    frame('rightFrame', 150, 400, 650, 700),
+    placed(th('root'), 100, 500, 520, 120),
+  ];
+  const laid = autoLayout(nodes, []);
+  const root = nodeOf(laid, 'root');
+  for (const id of ['leftFrame', 'rightFrame']) {
+    const f = nodeOf(laid, id);
+    assert(f.position.x < root.position.x && f.position.y < root.position.y, `${id} lost shared member`);
+    assert(f.position.x + f.width > root.position.x + 520, `${id} no longer wraps shared member`);
+  }
 });
 
 test('the benchmark canvases keep the arrow order', () => {

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -78,8 +78,73 @@ export function healLegacyNoteEdges(nodes: ThoughtNode[], edges: ThoughtEdge[]):
   return out;
 }
 
+type FrameSnapshot = {
+  id: string;
+  memberIds: string[];
+  rect: { x: number; y: number; width: number; height: number };
+  nestingLevel: number;
+};
+
+const FRAME_SIDE_PADDING = 36;
+const FRAME_TITLE_GAP = 44;
+const FRAME_NESTING_GAP = 24;
+const FRAME_MIN_WIDTH = 280;
+const FRAME_MIN_HEIGHT = 180;
+
+function snapshotLayoutFrames(allNodes: ThoughtNode[]): FrameSnapshot[] {
+  const frames = allNodes.filter((n) => n.data.stepKind === 'frame' && n.data.frameCarry !== false);
+  const snapshots = frames.map((frame) => {
+    const width = frame.measured?.width ?? frame.width ?? 0;
+    const height = frame.measured?.height ?? frame.height ?? 0;
+    const memberIds = allNodes
+      .filter((n) => {
+        if (n.id === frame.id || n.data.stepKind === 'frame') return false;
+        // Keep membership identical to frame dragging: the node center decides
+        // whether it belongs to the region, and membership is frozen before
+        // layout so nodes cannot switch frames while they are being moved.
+        const cx = n.position.x + (n.measured?.width ?? 520) / 2;
+        const cy = n.position.y + (n.measured?.height ?? 120) / 2;
+        return cx >= frame.position.x && cx <= frame.position.x + width
+          && cy >= frame.position.y && cy <= frame.position.y + height;
+      })
+      .map((n) => n.id);
+    return {
+      id: frame.id,
+      memberIds,
+      rect: { x: frame.position.x, y: frame.position.y, width, height },
+      nestingLevel: 0,
+    };
+  });
+
+  const contains = (outer: FrameSnapshot, inner: FrameSnapshot) => {
+    if (outer.id === inner.id) return false;
+    const a = outer.rect;
+    const b = inner.rect;
+    const strictlyLarger = a.width * a.height > b.width * b.height;
+    return strictlyLarger
+      && b.x >= a.x && b.y >= a.y
+      && b.x + b.width <= a.x + a.width
+      && b.y + b.height <= a.y + a.height;
+  };
+
+  // Level 0 is the innermost frame. Each enclosing layer gets more padding,
+  // which keeps nested frame borders from collapsing onto the same edge.
+  const memo = new Map<string, number>();
+  const levelOf = (frame: FrameSnapshot): number => {
+    const cached = memo.get(frame.id);
+    if (cached !== undefined) return cached;
+    const innerFrames = snapshots.filter((candidate) => contains(frame, candidate));
+    const level = innerFrames.length === 0 ? 0 : 1 + Math.max(...innerFrames.map(levelOf));
+    memo.set(frame.id, level);
+    return level;
+  };
+  for (const snapshot of snapshots) snapshot.nestingLevel = levelOf(snapshot);
+  return snapshots;
+}
+
 export function autoLayout(allNodes: ThoughtNode[], allEdges: ThoughtEdge[]): ThoughtNode[] {
   if (allNodes.length === 0) return allNodes;
+  const frameSnapshots = snapshotLayoutFrames(allNodes);
   // Content nodes (notes / files) are user-arranged material: layout never
   // moves them and their edges don't shape the column tree. A node whose
   // only parent is a content node simply roots its own chain.
@@ -557,7 +622,48 @@ export function autoLayout(allNodes: ThoughtNode[], allEdges: ThoughtEdge[]): Th
     positioned.set(note.id, { x, y });
   }
 
+  // --- Pass 6: Frame follow-up ---
+  // Frames are not part of the column tree. Instead, linked frames snapshot
+  // their members before layout and re-wrap those same members afterwards.
+  // This preserves the conversation layout law while keeping spatial regions
+  // attached to the nodes the user grouped.
+  const frameLayouts = new Map<string, { position: { x: number; y: number }; width: number; height: number }>();
+  const nodeById = new Map(allNodes.map((n) => [n.id, n]));
+  const contentKinds = new Set(['note', 'file', 'link']);
+  const snapshotsInnerToOuter = [...frameSnapshots].sort((a, b) => a.nestingLevel - b.nestingLevel);
+
+  for (const frame of snapshotsInnerToOuter) {
+    if (frame.memberIds.length === 0) continue;
+    const rects = frame.memberIds
+      .map((id) => {
+        const node = nodeById.get(id);
+        if (!node) return null;
+        const position = positioned.get(id) ?? node.position;
+        const width = node.measured?.width ?? node.width ?? LAYOUT_COL_WIDTH;
+        const height = contentKinds.has(node.data.stepKind ?? '')
+          ? (node.measured?.height ?? node.height ?? 120)
+          : Math.max(node.measured?.height ?? 0, node.height ?? 0, nodeHeight(node));
+        return { x: position.x, y: position.y, width, height };
+      })
+      .filter((r): r is { x: number; y: number; width: number; height: number } => r !== null);
+    if (rects.length === 0) continue;
+
+    const minX = Math.min(...rects.map((r) => r.x));
+    const minY = Math.min(...rects.map((r) => r.y));
+    const maxX = Math.max(...rects.map((r) => r.x + r.width));
+    const maxY = Math.max(...rects.map((r) => r.y + r.height));
+    const sidePadding = FRAME_SIDE_PADDING + frame.nestingLevel * FRAME_NESTING_GAP;
+    const topPadding = sidePadding + FRAME_TITLE_GAP;
+    const x = minX - sidePadding;
+    const y = minY - topPadding;
+    const width = Math.max(FRAME_MIN_WIDTH, maxX - minX + sidePadding * 2);
+    const height = Math.max(FRAME_MIN_HEIGHT, maxY - minY + topPadding + sidePadding);
+    frameLayouts.set(frame.id, { position: { x, y }, width, height });
+  }
+
   return allNodes.map((node) => {
+    const frameLayout = frameLayouts.get(node.id);
+    if (frameLayout) return { ...node, ...frameLayout };
     const pos = positioned.get(node.id);
     return pos ? { ...node, position: pos } : node;
   });


### PR DESCRIPTION
Fixes #32

Keep the existing conversation layout law unchanged, then re-wrap linked frames around the members they contained before auto layout.

Includes regression coverage for linked frames, unlinked frames, empty frames, nested frames, and overlapping frames with shared members.

Verified with layout tests, lint, production build, DSH build, and a real React Flow browser check.