### PR TITLE
fix(canvas): carry nested frames with outer frame drag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -567,8 +567,9 @@ function Canvas() {
     const fh = frame.measured?.height ?? frame.height ?? 0;
     const members = st.nodes
       .filter((n) => {
-        // multi-select drag already moves selected nodes — don't move them twice
-        if (n.id === frame.id || n.data.stepKind === 'frame' || n.selected) return false;
+        // multi-select drag already moves selected nodes — don't move them twice.
+        // Nested frames are members too, so an outer frame carries the whole region.
+        if (n.id === frame.id || n.selected) return false;
         const cx = n.position.x + (n.measured?.width ?? 520) / 2;
         const cy = n.position.y + (n.measured?.height ?? 120) / 2;
         return cx >= frame.position.x && cx <= frame.position.x + fw && cy >= frame.position.y && cy <= frame.position.y + fh;


### PR DESCRIPTION
Follow-up to the nested-frame behavior discussed in #32.

When a linked outer frame is dragged, nested frames whose centers are inside the outer frame now move with the same delta as the rest of the region.

This keeps the existing center-point membership rule and avoids double-moving selected nodes.

Verified with lint, production build, and a real browser drag check confirming the outer frame, inner frame, and contained node all receive the same displacement.